### PR TITLE
作り直し(`yoyo_malloc`)

### DIFF
--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -8,6 +8,7 @@ OBJDIR	:=	objs
 INCDIR	:=	includes
 FILES	:=	\
 			yoyo_actual_malloc.c\
+			yoyo_actual_free.c\
 			yoyo_arena_initialize.c\
 			yoyo_lock.c\
 			yoyo_malloc.c\
@@ -23,7 +24,7 @@ NAME	:=	libmalloc.a
 RM		:=	rm -rf
 
 CC		:=	gcc
-CFLAGS	:=	-Wall -Wextra -Werror -O2 -I$(INCDIR) -g -fsanitize=address
+CFLAGS	:=	-Wall -Wextra -Werror -O2 -I$(INCDIR) -g -fsanitize=undefined
 
 SONAME	:= 
 

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -7,12 +7,12 @@ SRCDIR	:=	srcs
 OBJDIR	:=	objs
 INCDIR	:=	includes
 FILES	:=	\
-			yoyo_malloc.c\
 			yoyo_actual_malloc.c\
+			yoyo_arena_initialize.c\
 			yoyo_lock.c\
+			yoyo_malloc.c\
 			yoyo_memory_alloc.c\
 			yoyo_realm_initialize.c\
-			yoyo_arena_initialize.c\
 			yoyo_zone_initialize.c\
 			yoyo_zone_utils.c\
 
@@ -22,7 +22,7 @@ NAME	:=	libmalloc.a
 RM		:=	rm -rf
 
 CC		:=	gcc
-CFLAGS	:=	-Wall -Wextra -Werror -I$(INCDIR) -g -fsanitize=address
+CFLAGS	:=	-Wall -Wextra -Werror -O2 -I$(INCDIR) -g -fsanitize=address
 
 SONAME	:= 
 

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -15,6 +15,7 @@ FILES	:=	\
 			yoyo_memory_alloc.c\
 			yoyo_realm_initialize.c\
 			yoyo_zone_initialize.c\
+			yoyo_zone_bitmap.c\
 			yoyo_zone_operation.c\
 			yoyo_zone_utils.c\
 			yoyo_debug.c\

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -8,6 +8,7 @@ OBJDIR	:=	objs
 INCDIR	:=	includes
 FILES	:=	\
 			yoyo_malloc.c\
+			yoyo_memory_alloc.c\
 			yoyo_realm_initialize.c\
 			yoyo_arena_initialize.c\
 			yoyo_zone_initialize.c\

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -1,0 +1,46 @@
+
+ifeq ($(HOSTTYPE),)
+	HOSTTYPE := $(shell uname -m)_$(shell uname -s)
+endif
+
+SRCDIR	:=	srcs
+OBJDIR	:=	objs
+INCDIR	:=	includes
+FILES	:=	\
+			yoyo_malloc.c\
+			yoyo_realm_initialize.c\
+			yoyo_arena_initialize.c\
+			yoyo_zone_initialize.c\
+			yoyo_zone_utils.c\
+
+SRCS	:=	$(FILES:%.c=$(SRCDIR)/%.c)
+OBJS	:=	$(FILES:%.c=$(OBJDIR)/%.o)
+NAME	:=	libmalloc.a
+RM		:=	rm -rf
+
+CC		:=	gcc
+CFLAGS	:=	-Wall -Wextra -Werror -I$(INCDIR) -g -fsanitize=address
+
+SONAME	:= 
+
+all:	malloc
+
+$(OBJDIR)/%.o: $(SRCDIR)/%.c
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+.PHONY:	malloc
+malloc:	$(NAME)
+	$(CC) $(CFLAGS) -o $@ main.c $(NAME)
+	./$@
+
+$(NAME):	$(OBJS)
+	ar rcs $(NAME) $(OBJS)
+
+clean:
+	$(RM)	$(OBJDIR)
+
+fclean:	clean
+	$(RM)	$(NAME)
+
+re:		fclean all

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -8,6 +8,8 @@ OBJDIR	:=	objs
 INCDIR	:=	includes
 FILES	:=	\
 			yoyo_malloc.c\
+			yoyo_actual_malloc.c\
+			yoyo_lock.c\
 			yoyo_memory_alloc.c\
 			yoyo_realm_initialize.c\
 			yoyo_arena_initialize.c\

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -14,6 +14,7 @@ FILES	:=	\
 			yoyo_memory_alloc.c\
 			yoyo_realm_initialize.c\
 			yoyo_zone_initialize.c\
+			yoyo_zone_operation.c\
 			yoyo_zone_utils.c\
 
 SRCS	:=	$(FILES:%.c=$(SRCDIR)/%.c)

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -9,6 +9,7 @@ INCDIR	:=	includes
 FILES	:=	\
 			yoyo_actual_malloc.c\
 			yoyo_actual_free.c\
+			yoyo_actual_realloc.c\
 			yoyo_arena_initialize.c\
 			yoyo_lock.c\
 			yoyo_malloc.c\

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -17,6 +17,8 @@ FILES	:=	\
 			yoyo_zone_initialize.c\
 			yoyo_zone_operation.c\
 			yoyo_zone_utils.c\
+			yoyo_debug.c\
+
 
 SRCS	:=	$(FILES:%.c=$(SRCDIR)/%.c)
 OBJS	:=	$(FILES:%.c=$(OBJDIR)/%.o)

--- a/yoyo/Makefile
+++ b/yoyo/Makefile
@@ -10,6 +10,7 @@ FILES	:=	\
 			yoyo_actual_malloc.c\
 			yoyo_actual_free.c\
 			yoyo_actual_realloc.c\
+			yoyo_visualize.c\
 			yoyo_arena_initialize.c\
 			yoyo_lock.c\
 			yoyo_malloc.c\

--- a/yoyo/includes/yoyo_common.h
+++ b/yoyo/includes/yoyo_common.h
@@ -1,6 +1,8 @@
 #ifndef YOYO_COMMON_H
 # define YOYO_COMMON_H
 
+// [デバッグ用出力]
+
 # include <unistd.h>
 # include <stdio.h>
 

--- a/yoyo/includes/yoyo_common.h
+++ b/yoyo/includes/yoyo_common.h
@@ -1,0 +1,40 @@
+#ifndef YOYO_COMMON_H
+# define YOYO_COMMON_H
+
+# include <unistd.h>
+# include <stdio.h>
+
+# define TX_RED "\e[31m"
+# define TX_GRN "\e[32m"
+# define TX_BLU "\e[34m"
+# define TX_YLW "\e[33m"
+# define TX_GRY "\e[30m"
+# define TX_RST "\e[0m"
+
+# ifdef NDEBUG
+#  define DEBUGSTRN(format) (0)
+#  define DEBUGSTR(format) (0)
+#  define DEBUGOUT(format, ...) (0)
+#  define DEBUGINFO(format, ...) (0)
+#  define DEBUGWARN(format, ...) (0)
+#  define DEBUGERR(format, ...) (0)
+#  define OUT_VAR_INT(var) (0)
+#  define OUT_VAR_SIZE_T(var) (0)
+#  define OUT_VAR_ADDR(var) (0)
+#  define OUT_VAR_STR(var) (0)
+#  define PRINT_STATE_AFTER(proc) proc;
+# else
+#  define DEBUGSTRN(format) dprintf(STDERR_FILENO, "%s[%s:%d %s] " format "%s", TX_GRY, __FILE__, __LINE__, __func__, TX_RST)
+#  define DEBUGSTR(format) dprintf(STDERR_FILENO, "%s[%s:%d %s] " format "%s\n", TX_GRY, __FILE__, __LINE__, __func__, TX_RST)
+#  define DEBUGOUT(format, ...) dprintf(STDERR_FILENO, "%s[%s:%d %s] " format "%s\n", TX_GRY, __FILE__, __LINE__, __func__, __VA_ARGS__, TX_RST)
+#  define DEBUGINFO(format, ...) dprintf(STDERR_FILENO, "[%s:%d %s] " format "\n", __FILE__, __LINE__, __func__, __VA_ARGS__)
+#  define DEBUGWARN(format, ...) dprintf(STDERR_FILENO, "%s[%s:%d %s] " format "%s\n", TX_YLW, __FILE__, __LINE__, __func__, __VA_ARGS__, TX_RST)
+#  define DEBUGERR(format, ...) dprintf(STDERR_FILENO, "%s[%s:%d %s] " format "%s\n", TX_RED, __FILE__, __LINE__, __func__, __VA_ARGS__, TX_RST)
+#  define OUT_VAR_INT(var) printf(#var " = %d\n", var)
+#  define OUT_VAR_SIZE_T(var) printf(#var " = %zu\n", var)
+#  define OUT_VAR_ADDR(var) printf(#var " = %p\n", var)
+#  define OUT_VAR_STR(var) printf(#var " = \"%s\"\n", var)
+#  define PRINT_STATE_AFTER(proc) DEBUGSTR("DA: " #proc); proc; show_alloc_mem();
+# endif
+
+#endif

--- a/yoyo/includes/yoyo_flag.h
+++ b/yoyo/includes/yoyo_flag.h
@@ -20,4 +20,7 @@
 // アドレス dst のフラグをアドレス src のフラグにしたものを返す
 # define COPY_FLAGS(dst, src) ((void *)((uintptr_t)ADDRESS_OF(dst) | (uintptr_t)ADDRESS_OF(src)))
 
+// この chunk が LARGE かどうかを判定する
+# define IS_LARGE_CHUNK(chunk) (!!((uintptr_t)((chunk)->next) & YOYO_FLAG_LARGE))
+
 #endif

--- a/yoyo/includes/yoyo_flag.h
+++ b/yoyo/includes/yoyo_flag.h
@@ -1,0 +1,23 @@
+#ifndef YOYO_FLAG_H
+# define YOYO_FLAG_H
+
+# include <stdlib.h>
+# include "yoyo_structure.h"
+
+# define YOYO_FLAG_LARGE 1u
+# define YOYO_FLAG_MASK 7u
+# define YOYO_FLAG_NOT_MASK (~(uintptr_t)7)
+
+// アドレス addr からフラグを切り落として正常なアドレスを返す
+# define ADDRESS_OF(addr) ((void*)((uintptr_t)addr & YOYO_FLAG_NOT_MASK))
+
+// chunk->next からフラグを切り落として正常なアドレスを返す
+# define NEXT_OF(chunk) ADDRESS_OF((chunk)->next)
+
+// アドレス addr にフラグ flags をセットしたものを返す
+# define SET_FLAGS(addr, flags) ((void*)(((uintptr_t)addr & YOYO_FLAG_NOT_MASK) | flags))
+
+// アドレス dst のフラグをアドレス src のフラグにしたものを返す
+# define COPY_FLAGS(dst, src) ((void *)((uintptr_t)ADDRESS_OF(dst) | (uintptr_t)ADDRESS_OF(src)))
+
+#endif

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -23,9 +23,12 @@ void	actual_free(void* addr);
 // yoyo_lock.c
 bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
 bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+bool	lock_subarena(t_yoyo_subarena* subarena);
+bool	try_lock_subarena(t_yoyo_subarena* subarena);
 bool	lock_zone(t_yoyo_zone* zone);
 bool	try_lock_zone(t_yoyo_zone* zone);
 bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+bool	unlock_subarena(t_yoyo_subarena* subarena);
 bool	unlock_zone(t_yoyo_zone* zone);
 
 // yoyo_memory_alloc.c

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -13,8 +13,18 @@
 
 t_yoyo_realm	g_yoyo_realm;
 
+// yoyo_actual_malloc.c
+void	yoyo_actual_malloc(size_t n);
+
+// yoyo_lock.c
+bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+bool	lock_zone(t_yoyo_zone* zone);
+bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+bool	unlock_zone(t_yoyo_zone* zone);
+
 // yoyo_memory_alloc.c
-void*	allocate_aligned_memory(size_t bytes);
+void*	allocate_memory(size_t bytes);
 void	deallocate_memory(void* start, size_t size);
 
 // yoyo_init_realm.c

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -13,8 +13,8 @@
 
 t_yoyo_realm	g_yoyo_realm;
 
-// yoyo_actual_malloc.c
-void	yoyo_actual_malloc(size_t n);
+// actual_malloc.c
+void*	actual_malloc(size_t n);
 
 // yoyo_lock.c
 bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
@@ -31,8 +31,10 @@ void	deallocate_memory(void* start, size_t size);
 bool	init_realm(bool multi_thread);
 
 // yoyo_arena_initialize.c
-bool	init_arena(t_yoyo_arena* arena, bool multi_thread);
-void	destroy_arena(t_yoyo_arena* arena);
+bool				init_arena(unsigned int index, bool multi_thread);
+void				destroy_arena(t_yoyo_arena* arena);
+t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+
 
 // yoyo_zone_initialize.c
 size_t			heap_bytes_for_zone_bytes(size_t zone_bytes);
@@ -41,6 +43,7 @@ t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_class zone_cla
 
 // yoyo_zone_utils.c
 size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class);
+t_yoyo_zone_class	zone_class_for_bytes(size_t n);
 
 
 

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -20,6 +20,9 @@ void*	actual_malloc(size_t n);
 // yoyo_actual_free.c
 void	actual_free(void* addr);
 
+// yoyo_actual_realloc.c
+void*	actual_realloc(void* addr, size_t n);
+
 // yoyo_lock.c
 bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
@@ -56,6 +59,7 @@ size_t	zone_bytes_for_zone_type(t_yoyo_zone_type zone_type);
 size_t	max_chunk_blocks_for_zone_type(t_yoyo_zone_type zone_type);
 t_yoyo_zone_type	zone_type_for_bytes(size_t n);
 unsigned int	get_block_index(const t_yoyo_zone* zone, const t_yoyo_chunk* head);
+t_yoyo_zone*	get_zone_of_chunk(const t_yoyo_chunk* chunk);
 
 // yoyo_zone_operation.c
 void	unmark_chunk(t_yoyo_zone* zone, const t_yoyo_chunk* chunk);

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -41,7 +41,7 @@ bool	init_realm(bool multi_thread);
 // yoyo_arena_initialize.c
 bool				init_arena(unsigned int index, bool multi_thread);
 void				destroy_arena(t_yoyo_arena* arena);
-t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
+t_yoyo_subarena*	get_subarena(const t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 
 
 // yoyo_zone_initialize.c
@@ -55,11 +55,12 @@ bool	is_used(const t_yoyo_zone* zone, unsigned int block_index);
 size_t	zone_bytes_for_zone_type(t_yoyo_zone_type zone_type);
 size_t	max_chunk_blocks_for_zone_type(t_yoyo_zone_type zone_type);
 t_yoyo_zone_type	zone_type_for_bytes(size_t n);
-unsigned int	get_block_index(t_yoyo_zone* zone, t_yoyo_chunk* head);
+unsigned int	get_block_index(const t_yoyo_zone* zone, const t_yoyo_chunk* head);
 
 // yoyo_zone_operation.c
-void	mark_chunk_as_free(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
-void	mark_chunk_as_used(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
+void	unmark_chunk(t_yoyo_zone* zone, const t_yoyo_chunk* chunk);
+void	mark_chunk_as_free(t_yoyo_zone* zone, const t_yoyo_chunk* chunk);
+void	mark_chunk_as_used(t_yoyo_zone* zone, const t_yoyo_chunk* chunk);
 
 // yoyo_debug.c
 void	print_zone_state(const t_yoyo_zone* zone);

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -15,6 +15,7 @@ t_yoyo_realm	g_yoyo_realm;
 
 // yoyo_memory_alloc.c
 void*	allocate_aligned_memory(size_t bytes);
+void	deallocate_memory(void* start, size_t size);
 
 // yoyo_init_realm.c
 bool	init_realm(bool multi_thread);
@@ -24,8 +25,9 @@ bool	init_arena(t_yoyo_arena* arena, bool multi_thread);
 void	destroy_arena(t_yoyo_arena* arena);
 
 // yoyo_zone_initialize.c
-size_t	heap_bytes_for_zone_bytes(size_t zone_bytes);
-bool	init_zone(t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class zone_class);
+size_t			heap_bytes_for_zone_bytes(size_t zone_bytes);
+bool			init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class zone_class);
+t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
 
 // yoyo_zone_utils.c
 size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class);

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -4,6 +4,7 @@
 # include "yoyo_common.h"
 # include "yoyo_time.h"
 # include "yoyo_structure.h"
+# include "yoyo_flag.h"
 # include <stdio.h>
 # include <unistd.h>
 # include <string.h>
@@ -25,8 +26,8 @@ bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
 bool	unlock_zone(t_yoyo_zone* zone);
 
 // yoyo_memory_alloc.c
-void*	allocate_memory(size_t bytes);
-void	deallocate_memory(void* start, size_t size);
+void*	map_memory(size_t bytes);
+void	unmap_memory(void* start, size_t size);
 
 // yoyo_init_realm.c
 bool	init_realm(bool multi_thread);

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -13,6 +13,9 @@
 
 t_yoyo_realm	g_yoyo_realm;
 
+// yoyo_memory_alloc.c
+void*	allocate_aligned_memory(size_t bytes);
+
 // yoyo_init_realm.c
 bool	init_realm(bool multi_thread);
 

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -1,0 +1,32 @@
+#ifndef YOYO_INTERNAL_MALLOC_H
+# define YOYO_INTERNAL_MALLOC_H
+
+# include "yoyo_common.h"
+# include "yoyo_time.h"
+# include "yoyo_structure.h"
+# include <stdio.h>
+# include <unistd.h>
+# include <string.h>
+# include <sys/mman.h>
+# include <errno.h>
+# include <assert.h>
+
+t_yoyo_realm	g_yoyo_realm;
+
+// yoyo_init_realm.c
+bool	init_realm(bool multi_thread);
+
+// yoyo_arena_initialize.c
+bool	init_arena(t_yoyo_arena* arena, bool multi_thread);
+void	destroy_arena(t_yoyo_arena* arena);
+
+// yoyo_zone_initialize.c
+size_t	heap_bytes_for_zone_bytes(size_t zone_bytes);
+bool	init_zone(t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class zone_class);
+
+// yoyo_zone_utils.c
+size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class);
+
+
+
+#endif

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -21,13 +21,13 @@ void*	actual_malloc(size_t n);
 void	actual_free(void* addr);
 
 // yoyo_lock.c
-bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
-bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
+bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 bool	lock_subarena(t_yoyo_subarena* subarena);
 bool	try_lock_subarena(t_yoyo_subarena* subarena);
 bool	lock_zone(t_yoyo_zone* zone);
 bool	try_lock_zone(t_yoyo_zone* zone);
-bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 bool	unlock_subarena(t_yoyo_subarena* subarena);
 bool	unlock_zone(t_yoyo_zone* zone);
 
@@ -41,23 +41,23 @@ bool	init_realm(bool multi_thread);
 // yoyo_arena_initialize.c
 bool				init_arena(unsigned int index, bool multi_thread);
 void				destroy_arena(t_yoyo_arena* arena);
-t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 
 
 // yoyo_zone_initialize.c
-size_t			heap_bytes_for_zone_bytes(size_t zone_bytes);
-bool			init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class zone_class);
-t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
+t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 
 // yoyo_zone_utils.c
-size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class);
-size_t	max_chunk_blocks_for_zone_class(t_yoyo_zone_class zone_class);
-t_yoyo_zone_class	zone_class_for_bytes(size_t n);
+size_t	zone_bytes_for_zone_type(t_yoyo_zone_type zone_type);
+size_t	max_chunk_blocks_for_zone_type(t_yoyo_zone_type zone_type);
+t_yoyo_zone_type	zone_type_for_bytes(size_t n);
 unsigned int	get_block_index(t_yoyo_zone* zone, t_yoyo_chunk* head);
 
 // yoyo_zone_operation.c
 void	mark_chunk_as_free(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
 void	mark_chunk_as_used(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
 
+// yoyo_debug.c
+void	print_zone_state(const t_yoyo_zone* zone);
 
 #endif

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -14,8 +14,11 @@
 
 t_yoyo_realm	g_yoyo_realm;
 
-// actual_malloc.c
+// yoyo_actual_malloc.c
 void*	actual_malloc(size_t n);
+
+// yoyo_actual_free.c
+void	actual_free(void* addr);
 
 // yoyo_lock.c
 bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -23,6 +23,9 @@ void	actual_free(void* addr);
 // yoyo_actual_realloc.c
 void*	actual_realloc(void* addr, size_t n);
 
+// yoyo_visualize.c
+void	actual_show_alloc_mem(void);
+
 // yoyo_lock.c
 bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
@@ -51,8 +54,9 @@ t_yoyo_subarena*	get_subarena(const t_yoyo_arena* arena, t_yoyo_zone_type zone_t
 t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 
 // yoyo_zone_bitmap.c
-bool	is_head(const t_yoyo_zone* zone, unsigned int block_index);
-bool	is_used(const t_yoyo_zone* zone, unsigned int block_index);
+bool			is_head(const t_yoyo_zone* zone, unsigned int block_index);
+bool			is_used(const t_yoyo_zone* zone, unsigned int block_index);
+t_yoyo_chunk*	get_chunk_by_index(t_yoyo_zone* zone, unsigned int block_index);
 
 // yoyo_zone_utils.c
 size_t	zone_bytes_for_zone_type(t_yoyo_zone_type zone_type);

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -20,6 +20,7 @@ void*	actual_malloc(size_t n);
 bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
 bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
 bool	lock_zone(t_yoyo_zone* zone);
+bool	try_lock_zone(t_yoyo_zone* zone);
 bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class);
 bool	unlock_zone(t_yoyo_zone* zone);
 

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -47,6 +47,10 @@ t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 // yoyo_zone_initialize.c
 t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_type zone_type);
 
+// yoyo_zone_bitmap.c
+bool	is_head(const t_yoyo_zone* zone, unsigned int block_index);
+bool	is_used(const t_yoyo_zone* zone, unsigned int block_index);
+
 // yoyo_zone_utils.c
 size_t	zone_bytes_for_zone_type(t_yoyo_zone_type zone_type);
 size_t	max_chunk_blocks_for_zone_type(t_yoyo_zone_type zone_type);
@@ -59,5 +63,8 @@ void	mark_chunk_as_used(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
 
 // yoyo_debug.c
 void	print_zone_state(const t_yoyo_zone* zone);
+void	print_zone_bitmap_state(const t_yoyo_zone* zone);
+void	print_memory_state(const void* addr);
+
 
 #endif

--- a/yoyo/includes/yoyo_internal.h
+++ b/yoyo/includes/yoyo_internal.h
@@ -43,8 +43,13 @@ t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_class zone_cla
 
 // yoyo_zone_utils.c
 size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class);
+size_t	max_chunk_blocks_for_zone_class(t_yoyo_zone_class zone_class);
 t_yoyo_zone_class	zone_class_for_bytes(size_t n);
+unsigned int	get_block_index(t_yoyo_zone* zone, t_yoyo_chunk* head);
 
+// yoyo_zone_operation.c
+void	mark_chunk_as_free(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
+void	mark_chunk_as_used(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
 
 
 #endif

--- a/yoyo/includes/yoyo_malloc.h
+++ b/yoyo/includes/yoyo_malloc.h
@@ -1,0 +1,10 @@
+#ifndef YOYO_MALLOC_H
+# define YOYO_MALLOC_H
+
+# include <stdlib.h>
+
+void*	yoyo_malloc(size_t n);
+void	yoyo_free(void* addr);
+void*	yoyo_realloc(void* addr, size_t n);
+
+#endif

--- a/yoyo/includes/yoyo_malloc.h
+++ b/yoyo/includes/yoyo_malloc.h
@@ -6,5 +6,6 @@
 void*	yoyo_malloc(size_t n);
 void	yoyo_free(void* addr);
 void*	yoyo_realloc(void* addr, size_t n);
+void	show_alloc_mem(void);
 
 #endif

--- a/yoyo/includes/yoyo_structure.h
+++ b/yoyo/includes/yoyo_structure.h
@@ -21,7 +21,7 @@ typedef unsigned char	t_bitfield;
 
 
 // [chunk ヘッダ構造体]
-// 
+// chunk ヘッダ t_yoyo_chunk の後にユーザが使用可能な領域が続く.
 // 
 //         t_yoyo_chunk        |    (chunk body)     
 // +-------------+-------------+---------//---------+
@@ -36,7 +36,7 @@ typedef struct	s_yoyo_chunk {
 }	t_yoyo_chunk;
 
 // [LARGE chunk ヘッダ構造体]
-// 
+// LARGE chunk ヘッダ t_yoyo_large_chunk の後ろに通常の chunk が続く形になっている.
 // 
 //             t_yoyo_large_chunk          |       t_yoyo_chunk        |    (chunk body)     
 // +------------+-------------+------------+-------------+-------------+---------//---------+

--- a/yoyo/includes/yoyo_structure.h
+++ b/yoyo/includes/yoyo_structure.h
@@ -11,11 +11,11 @@
 // a を bの倍数に切り下げる
 # define FLOOR_BY(a, b) (a / b * b)
 
-typedef enum e_yoyo_zone_class {
+typedef enum e_yoyo_zone_type {
 	YOYO_ZONE_TINY,
 	YOYO_ZONE_SMALL,
 	YOYO_ZONE_LARGE,
-}	t_yoyo_zone_class;
+}	t_yoyo_zone_type;
 
 typedef unsigned char	t_bitfield;
 
@@ -87,7 +87,7 @@ typedef struct	s_yoyo_zone {
 	bool				multi_thread;
 
 	// ゾーン種別
-	t_yoyo_zone_class	zone_class;
+	t_yoyo_zone_type	zone_type;
 
 	// free リスト
 	t_yoyo_chunk*		frees;

--- a/yoyo/includes/yoyo_structure.h
+++ b/yoyo/includes/yoyo_structure.h
@@ -123,14 +123,18 @@ typedef struct	s_yoyo_zone {
 
 typedef struct	s_yoyo_normal_arena {
 	// arena ロック
-	pthread_mutex_t		lock;
+	pthread_mutex_t	lock;
+	// マルチスレッドモードかどうか
+	bool			multi_thread;
 	// zone リスト
-	t_yoyo_zone*		head;
+	t_yoyo_zone*	head;
 }	t_yoyo_normal_arena;
 
 typedef struct	s_yoyo_large_arena {
 	// arena ロック
 	pthread_mutex_t		lock;
+	// マルチスレッドモードかどうか
+	bool				multi_thread;
 	// 使用済み LARGE chunk リスト
 	t_yoyo_large_chunk*	allocated;
 }	t_yoyo_large_arena;
@@ -138,6 +142,8 @@ typedef struct	s_yoyo_large_arena {
 typedef struct	s_yoyo_subarena {
 	// arena ロック
 	pthread_mutex_t	lock;
+	// マルチスレッドモードかどうか
+	bool			multi_thread;
 	// なんかしらのポインタ
 	void*			some;
 }	t_yoyo_subarena;

--- a/yoyo/includes/yoyo_structure.h
+++ b/yoyo/includes/yoyo_structure.h
@@ -44,6 +44,8 @@ typedef struct	s_yoyo_chunk {
 // M in PDF
 # define ZONE_SMALL_BYTE ((size_t)(8 * 1024 * 1024))
 
+typedef unsigned int block_index_t;
+
 // [TINY/SMALL zone 構造体]
 // ただし固定長の部分のみ. ビット配列部分はここに入っていない.
 typedef struct	s_yoyo_zone {
@@ -55,6 +57,9 @@ typedef struct	s_yoyo_zone {
 
 	// マルチスレッドモードかどうか
 	bool				multi_thread;
+
+	// ゾーン種別
+	t_yoyo_zone_class	zone_class;
 
 	// free リスト
 	t_yoyo_chunk*		frees;

--- a/yoyo/includes/yoyo_structure.h
+++ b/yoyo/includes/yoyo_structure.h
@@ -1,0 +1,141 @@
+#ifndef YOYO_STRUCTURE_H
+# define YOYO_STRUCTURE_H
+
+# include <stdlib.h>
+# include <stdbool.h>
+# include <pthread.h>
+
+# define ARENA_MAX	5
+# define CEIL_BY(a, b) (a ? ((a - 1) / b + 1) * b : b)
+# define FLOOR_BY(a, b) (a / b * b)
+
+typedef enum e_yoyo_zone_class {
+	YOYO_ZONE_TINY,
+	YOYO_ZONE_SMALL,
+	YOYO_ZONE_LARGE,
+}	t_yoyo_zone_class;
+
+typedef unsigned long	t_bitfield;
+
+
+// [chunk 構造体]
+typedef struct	s_yoyo_chunk {
+	// chunk のブロック数(ヘッダ含む)
+	size_t					blocks;
+	// フリーリストにおける次の chunk への参照.
+	// (末尾3ビットにはフラグがエンコードされている)
+	struct s_yoyo_chunk*	next;
+}	t_yoyo_chunk;
+
+# define BLOCK_UNIT_SIZE (CEIL_BY(sizeof(t_yoyo_chunk), sizeof(size_t)))
+# define BLOCKS_FOR_SIZE(n) (QUANTIZE(n, BLOCK_UNIT_SIZE) / BLOCK_UNIT_SIZE)
+
+// n in PDF
+# define TINY_MAX_CHUNK_BYTE ((size_t)992)
+// n as blocks
+# define TINY_MAX_CHUNK_BLOCK (BLOCKS_FOR_SIZE(TINY_MAX_CHUNK_BYTE))
+// m in PDF
+# define SMALL_MAX_CHUNK_BYTE ((size_t)15360)
+// m as blocks
+# define SMALL_MAX_CHUNK_BLOCK (BLOCKS_FOR_SIZE(SMALL_MAX_CHUNK_BYTE))
+
+// N in PDF
+# define ZONE_TINY_BYTE ((size_t)(1024 * 1024))
+// M in PDF
+# define ZONE_SMALL_BYTE ((size_t)(8 * 1024 * 1024))
+
+// [TINY/SMALL zone 構造体]
+// ただし固定長の部分のみ. ビット配列部分はここに入っていない.
+typedef struct	s_yoyo_zone {
+	// 次の zone
+	struct s_yoyo_zone_*	next;
+
+	// zone ロック
+	pthread_mutex_t			lock;
+
+	// マルチスレッドモードかどうか
+	bool					multi_thread;
+
+	// free リスト
+	t_yoyo_chunk*			frees;
+
+	// previous free
+	t_yoyo_chunk*			free_prev;
+
+	// zone 全体のブロック数
+	unsigned int			blocks_zone;
+	// zone のうち heap 部分のブロック数
+	unsigned int			blocks_heap;
+
+	// heap のうち使用されていないブロック数
+	unsigned int			blocks_free;
+
+	// heap のうち使用されているブロック数
+	unsigned int			blocks_used;
+
+	// blocks_heap = blocks_free + blocks_used
+
+	// zone 先頭から heads ビット配列へのバイトオフセット
+	// heads ビット配列のバイト数は ceil(blocks_heap / 8)
+	unsigned int			offset_bitmap_heads;
+
+	// zone 先頭から used ビット配列へのバイトオフセット
+	// used ビット配列のバイト数は ceil(blocks_heap / 8)
+	unsigned int			offset_bitmap_used;
+
+	// zone 先頭から ヒープ先頭へのバイトオフセット
+	unsigned int			offset_heap;
+
+}	t_yoyo_zone;
+
+typedef struct	s_yoyo_normal_arena {
+	pthread_mutex_t		lock;
+	t_yoyo_zone*		head;
+}	t_yoyo_normal_arena;
+
+typedef struct	s_yoyo_large_arena {
+	pthread_mutex_t		lock;
+}	t_yoyo_large_arena;
+
+typedef struct	s_yoyo_subarena {
+	// arena ロック
+	pthread_mutex_t	lock;
+	// 先頭 zone(TINY, SMALL) または chunk(LARGE) へのポインタ
+	// キャストして使うこと
+	void*			head;
+}	t_yoyo_subarena;
+
+// [arena 構造体]
+typedef struct	s_yoyo_arena {
+	bool			initialized;
+	// マルチスレッドモードかどうか
+	bool			multi_thread;
+
+	// TINY zone 管理ヘッダ
+	t_yoyo_subarena	tiny;
+	// SMALL zone 管理ヘッダ
+	t_yoyo_subarena	small;
+	// LARGE zone 管理ヘッダ
+	t_yoyo_subarena	large;
+}	t_yoyo_arena;
+
+
+// [realm 構造体]
+typedef struct	s_yoyo_realm {
+	// 初期化済みフラグ
+	bool			initialized;
+	// 使用可能な arena の総数.
+	// arena_count == 1 は シングルスレッドモードであることと同値.
+	// !initialized の時は 1 とみなすこと.
+	unsigned int	arena_count;
+
+	// arena 配列
+	// インデックス 0...arena_count の範囲が実際に利用可能.
+	t_yoyo_arena	arenas[ARENA_MAX];
+
+}	t_yoyo_realm;
+
+// シングルスレッドモード ではロックを取らない.
+// (マルチスレッドモード ではロックを取る.)
+
+#endif

--- a/yoyo/includes/yoyo_time.h
+++ b/yoyo/includes/yoyo_time.h
@@ -1,0 +1,11 @@
+#ifndef YOYO_TIME_H
+# define YOYO_TIME_H
+
+# include <sys/time.h>
+typedef struct timeval t_tv;
+# define STIME(t0) (1000000 * (unsigned long long)t0.tv_sec + (unsigned long long)t0.tv_usec)
+# define TIME_DIFF(t0, t1) (STIME(t1) - STIME(t0))
+# define SPRINT_START t_tv yo_t0; gettimeofday(&yo_t0, NULL);
+# define SPRINT_END(label) t_tv yo_t1; gettimeofday(&yo_t1, NULL); dprintf(STDERR_FILENO, "<time> %s %llu\n", label, TIME_DIFF(yo_t0, yo_t1))
+
+#endif

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -67,6 +67,23 @@ void	free_large_basic() {
 	yoyo_free(mem1);
 }
 
+void	realloc_basic() {
+	void*	mem1 = yoyo_realloc(NULL, 60);
+	printf("mem1 = %p\n", mem1);
+	void*	mem2 = yoyo_realloc(mem1, 20);
+	printf("mem2 = %p\n", mem2);
+	void*	mem3 = yoyo_realloc(mem2, 24);
+	printf("mem3 = %p\n", mem3);
+	void*	mem4 = yoyo_realloc(mem3, 4000);
+	printf("mem4 = %p\n", mem4);
+	void*	mem5 = yoyo_realloc(mem4, 40000);
+	printf("mem5 = %p\n", mem5);
+	void*	mem6 = yoyo_realloc(mem5, 20000);
+	printf("mem6 = %p\n", mem6);
+	void*	mem7 = yoyo_realloc(mem6, 1);
+	printf("mem7 = %p\n", mem7);
+}
+
 int main() {
 	// printf("%zu\n", sizeof(bool));
 	// printf("%zu\n", sizeof(unsigned int));
@@ -85,5 +102,7 @@ int main() {
 	// malloc_large_basic();
 
 	// free_tiny_basic();
-	free_large_basic();
+	// free_large_basic();
+
+	realloc_basic();
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -1,0 +1,21 @@
+#include "includes/yoyo_structure.h"
+#include "includes/yoyo_internal.h"
+
+#include <stdio.h>
+
+__attribute__((constructor))
+static void init_yoyo() {
+    init_realm(true);
+}
+
+int main() {
+	printf("%zu\n", sizeof(bool));
+	printf("%zu\n", sizeof(unsigned int));
+	printf("%zu\n", sizeof(pthread_mutex_t));
+	printf("%zu\n", sizeof(t_yoyo_zone));
+
+	size_t	zone_tiny_bytes = 1024 * 1024;
+	size_t	zone_small_bytes = 8 * 1024 * 1024;
+	printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_tiny_bytes));
+	printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_small_bytes));
+}

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -18,6 +18,7 @@ void	malloc_tiny_basic() {
 	printf("%p\n", mem);
 	mem = yoyo_malloc(100);
 	printf("%p\n", mem);
+	show_alloc_mem();
 }
 
 void	malloc_tiny_all() {
@@ -74,14 +75,18 @@ void	realloc_basic() {
 	printf("mem2 = %p\n", mem2);
 	void*	mem3 = yoyo_realloc(mem2, 24);
 	printf("mem3 = %p\n", mem3);
+	show_alloc_mem();
 	void*	mem4 = yoyo_realloc(mem3, 4000);
 	printf("mem4 = %p\n", mem4);
+	show_alloc_mem();
 	void*	mem5 = yoyo_realloc(mem4, 40000);
 	printf("mem5 = %p\n", mem5);
 	void*	mem6 = yoyo_realloc(mem5, 20000);
 	printf("mem6 = %p\n", mem6);
+	show_alloc_mem();
 	void*	mem7 = yoyo_realloc(mem6, 1);
 	printf("mem7 = %p\n", mem7);
+	show_alloc_mem();
 }
 
 int main() {
@@ -97,12 +102,13 @@ int main() {
 
 	// t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
 	// printf("%p\n", tiny);
-	// malloc_tiny_basic();
+	malloc_tiny_basic();
 	// malloc_tiny_all();
 	// malloc_large_basic();
 
 	// free_tiny_basic();
 	// free_large_basic();
 
-	realloc_basic();
+	show_alloc_mem();
+	// realloc_basic();
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -5,7 +5,7 @@
 
 __attribute__((constructor))
 static void init_yoyo() {
-    init_realm(true);
+	init_realm(true);
 }
 
 int main() {
@@ -18,4 +18,17 @@ int main() {
 	size_t	zone_small_bytes = 8 * 1024 * 1024;
 	printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_tiny_bytes));
 	printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_small_bytes));
+
+	void* tiny = allocate_aligned_memory(ZONE_TINY_BYTE);
+	printf("%p\n", tiny);
+	printf("%d\n", *(char*)tiny);
+	memset(tiny, '9', ZONE_TINY_BYTE);
+	// memset(tiny, '9', ZONE_TINY_BYTE + 1); // The signal is caused by a WRITE memory access.
+	printf("%d\n", *(char*)tiny);
+	void* small = allocate_aligned_memory(ZONE_SMALL_BYTE);
+	printf("%p\n", small);
+	printf("%d\n", *(char*)small);
+	memset(small, '9', ZONE_SMALL_BYTE);
+	// memset(small, '9', ZONE_SMALL_BYTE + 1); // The signal is caused by a WRITE memory access.
+	printf("%d\n", *(char*)small);
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -37,6 +37,15 @@ void	malloc_large_basic() {
 	printf("%p\n", mem);
 }
 
+void	free_tiny_basic() {
+	void* mem1 = yoyo_malloc(1);
+	printf("mem1 = %p\n", mem1);
+	void* mem2 = yoyo_malloc(1);
+	printf("mem2 = %p\n", mem2);
+	yoyo_free(mem1);
+	yoyo_free(mem2);
+}
+
 int main() {
 	// printf("%zu\n", sizeof(bool));
 	// printf("%zu\n", sizeof(unsigned int));
@@ -50,7 +59,9 @@ int main() {
 
 	// t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
 	// printf("%p\n", tiny);
-	malloc_tiny_basic();
+	// malloc_tiny_basic();
 	// malloc_tiny_all();
-	malloc_large_basic();
+	// malloc_large_basic();
+
+	free_tiny_basic();
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -45,27 +45,29 @@ void	free_tiny_basic() {
 	printf("mem2 = %p\n", mem2);
 	void* mem3 = yoyo_malloc(1);
 	printf("mem3 = %p\n", mem3);
-	print_memory_state(mem1);
-	print_memory_state(mem2);
-	print_memory_state(mem3);
+	show_alloc_mem();
 	yoyo_free(mem1);
 	yoyo_free(mem3);
 	yoyo_free(mem2);
+	show_alloc_mem();
 }
 
 void	free_large_basic() {
+	show_alloc_mem();
 	void* mem1 = yoyo_malloc(100000);
 	printf("mem1 = %p\n", mem1);
 	void* mem2 = yoyo_malloc(500000);
 	printf("mem2 = %p\n", mem2);
 	void* mem3 = yoyo_malloc(12500000);
 	printf("mem3 = %p\n", mem2);
+	show_alloc_mem();
 	print_memory_state(mem1);
 	print_memory_state(mem2);
 	print_memory_state(mem3);
 	yoyo_free(mem2);
 	yoyo_free(mem3);
 	yoyo_free(mem1);
+	show_alloc_mem();
 }
 
 void	realloc_basic() {
@@ -102,13 +104,12 @@ int main() {
 
 	// t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
 	// printf("%p\n", tiny);
-	malloc_tiny_basic();
+	// malloc_tiny_basic();
 	// malloc_tiny_all();
 	// malloc_large_basic();
 
-	// free_tiny_basic();
+	free_tiny_basic();
 	// free_large_basic();
 
-	show_alloc_mem();
 	// realloc_basic();
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -19,16 +19,6 @@ int main() {
 	printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_tiny_bytes));
 	printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_small_bytes));
 
-	void* tiny = allocate_aligned_memory(ZONE_TINY_BYTE);
+	t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
 	printf("%p\n", tiny);
-	printf("%d\n", *(char*)tiny);
-	memset(tiny, '9', ZONE_TINY_BYTE);
-	// memset(tiny, '9', ZONE_TINY_BYTE + 1); // The signal is caused by a WRITE memory access.
-	printf("%d\n", *(char*)tiny);
-	void* small = allocate_aligned_memory(ZONE_SMALL_BYTE);
-	printf("%p\n", small);
-	printf("%d\n", *(char*)small);
-	memset(small, '9', ZONE_SMALL_BYTE);
-	// memset(small, '9', ZONE_SMALL_BYTE + 1); // The signal is caused by a WRITE memory access.
-	printf("%d\n", *(char*)small);
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -11,18 +11,22 @@ static void init_yoyo() {
 }
 
 int main() {
-	printf("%zu\n", sizeof(bool));
-	printf("%zu\n", sizeof(unsigned int));
-	printf("%zu\n", sizeof(pthread_mutex_t));
-	printf("%zu\n", sizeof(t_yoyo_zone));
+	// printf("%zu\n", sizeof(bool));
+	// printf("%zu\n", sizeof(unsigned int));
+	// printf("%zu\n", sizeof(pthread_mutex_t));
+	// printf("%zu\n", sizeof(t_yoyo_zone));
 
-	size_t	zone_tiny_bytes = 1024 * 1024;
-	size_t	zone_small_bytes = 8 * 1024 * 1024;
-	printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_tiny_bytes));
-	printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_small_bytes));
+	// size_t	zone_tiny_bytes = 1024 * 1024;
+	// size_t	zone_small_bytes = 8 * 1024 * 1024;
+	// printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_tiny_bytes));
+	// printf("bytes: %zu\n", heap_bytes_for_zone_bytes(zone_small_bytes));
 
-	t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
-	printf("%p\n", tiny);
+	// t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
+	// printf("%p\n", tiny);
 
 	yoyo_malloc(100);
+	yoyo_malloc(200);
+	yoyo_malloc(5000);
+	yoyo_malloc(300);
+	yoyo_malloc(4001);
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -42,9 +42,13 @@ void	free_tiny_basic() {
 	printf("mem1 = %p\n", mem1);
 	void* mem2 = yoyo_malloc(1);
 	printf("mem2 = %p\n", mem2);
+	void* mem3 = yoyo_malloc(1);
+	printf("mem3 = %p\n", mem3);
 	print_memory_state(mem1);
 	print_memory_state(mem2);
+	print_memory_state(mem3);
 	yoyo_free(mem1);
+	yoyo_free(mem3);
 	yoyo_free(mem2);
 }
 

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -1,5 +1,7 @@
 #include "includes/yoyo_structure.h"
 #include "includes/yoyo_internal.h"
+#include "includes/yoyo_malloc.h"
+
 
 #include <stdio.h>
 
@@ -21,4 +23,6 @@ int main() {
 
 	t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
 	printf("%p\n", tiny);
+
+	yoyo_malloc(100);
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -10,6 +10,13 @@ static void init_yoyo() {
 	init_realm(true);
 }
 
+void	malloc_tiny_all() {
+	for (int i = 0; i < 1025; ++i) {
+		void* mem = yoyo_malloc(992);
+		printf("%d -> %p\n", i, mem);
+	}
+}
+
 int main() {
 	// printf("%zu\n", sizeof(bool));
 	// printf("%zu\n", sizeof(unsigned int));
@@ -23,10 +30,5 @@ int main() {
 
 	// t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
 	// printf("%p\n", tiny);
-
-	yoyo_malloc(100);
-	yoyo_malloc(200);
-	yoyo_malloc(5000);
-	yoyo_malloc(300);
-	yoyo_malloc(4001);
+	malloc_tiny_all();
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -42,6 +42,8 @@ void	free_tiny_basic() {
 	printf("mem1 = %p\n", mem1);
 	void* mem2 = yoyo_malloc(1);
 	printf("mem2 = %p\n", mem2);
+	print_memory_state(mem1);
+	print_memory_state(mem2);
 	yoyo_free(mem1);
 	yoyo_free(mem2);
 }
@@ -53,6 +55,9 @@ void	free_large_basic() {
 	printf("mem2 = %p\n", mem2);
 	void* mem3 = yoyo_malloc(12500000);
 	printf("mem3 = %p\n", mem2);
+	print_memory_state(mem1);
+	print_memory_state(mem2);
+	print_memory_state(mem3);
 	yoyo_free(mem2);
 	yoyo_free(mem3);
 	yoyo_free(mem1);
@@ -75,6 +80,6 @@ int main() {
 	// malloc_tiny_all();
 	// malloc_large_basic();
 
-	free_tiny_basic();
-	// free_large_basic();
+	// free_tiny_basic();
+	free_large_basic();
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -51,7 +51,10 @@ void	free_large_basic() {
 	printf("mem1 = %p\n", mem1);
 	void* mem2 = yoyo_malloc(500000);
 	printf("mem2 = %p\n", mem2);
+	void* mem3 = yoyo_malloc(12500000);
+	printf("mem3 = %p\n", mem2);
 	yoyo_free(mem2);
+	yoyo_free(mem3);
 	yoyo_free(mem1);
 }
 
@@ -72,6 +75,6 @@ int main() {
 	// malloc_tiny_all();
 	// malloc_large_basic();
 
-	// free_tiny_basic();
-	free_large_basic();
+	free_tiny_basic();
+	// free_large_basic();
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -46,6 +46,15 @@ void	free_tiny_basic() {
 	yoyo_free(mem2);
 }
 
+void	free_large_basic() {
+	void* mem1 = yoyo_malloc(100000);
+	printf("mem1 = %p\n", mem1);
+	void* mem2 = yoyo_malloc(500000);
+	printf("mem2 = %p\n", mem2);
+	yoyo_free(mem2);
+	yoyo_free(mem1);
+}
+
 int main() {
 	// printf("%zu\n", sizeof(bool));
 	// printf("%zu\n", sizeof(unsigned int));
@@ -63,5 +72,6 @@ int main() {
 	// malloc_tiny_all();
 	// malloc_large_basic();
 
-	free_tiny_basic();
+	// free_tiny_basic();
+	free_large_basic();
 }

--- a/yoyo/main.c
+++ b/yoyo/main.c
@@ -10,11 +10,31 @@ static void init_yoyo() {
 	init_realm(true);
 }
 
+void	malloc_tiny_basic() {
+	void* mem;
+	mem = yoyo_malloc(1);
+	printf("%p\n", mem);
+	mem = yoyo_malloc(10);
+	printf("%p\n", mem);
+	mem = yoyo_malloc(100);
+	printf("%p\n", mem);
+}
+
 void	malloc_tiny_all() {
 	for (int i = 0; i < 1025; ++i) {
 		void* mem = yoyo_malloc(992);
 		printf("%d -> %p\n", i, mem);
 	}
+}
+
+void	malloc_large_basic() {
+	void* mem;
+	mem = yoyo_malloc(100000);
+	printf("%p\n", mem);
+	mem = yoyo_malloc(500000);
+	printf("%p\n", mem);
+	mem = yoyo_malloc(100000000);
+	printf("%p\n", mem);
 }
 
 int main() {
@@ -30,5 +50,7 @@ int main() {
 
 	// t_yoyo_zone* tiny = allocate_zone(&g_yoyo_realm.arenas[0], YOYO_ZONE_TINY);
 	// printf("%p\n", tiny);
-	malloc_tiny_all();
+	malloc_tiny_basic();
+	// malloc_tiny_all();
+	malloc_large_basic();
 }

--- a/yoyo/srcs/yoyo_actual_free.c
+++ b/yoyo/srcs/yoyo_actual_free.c
@@ -1,0 +1,89 @@
+#include "yoyo_internal.h"
+
+
+static void	free_from_normal_zone(t_yoyo_chunk* chunk) {
+	// [まず chunk が TINY / SMALL のどちらかを判定する]
+	// -> blocks から計算できるはず
+	const size_t whole_blocks = chunk->blocks;
+	assert(whole_blocks > 0);
+	const size_t actual_blocks = whole_blocks - 1;
+	assert(actual_blocks > 0);
+	t_yoyo_zone_class zone_class = zone_class_for_bytes(actual_blocks * BLOCK_UNIT_SIZE);
+	DEBUGOUT("zone_class is %d", zone_class);
+	assert(zone_class != YOYO_ZONE_LARGE);
+
+	// [対応する zone に飛ぶ]
+	uintptr_t zone_mask = ~((zone_class == YOYO_ZONE_TINY ? ZONE_TINY_BYTE : ZONE_SMALL_BYTE) - 1);
+	DEBUGOUT("zone_mask is %lx", zone_mask);
+	t_yoyo_zone*	zone = (t_yoyo_zone*)((uintptr_t)chunk & zone_mask);
+	DEBUGOUT("zone: %p", zone);
+
+	// [ロックを取る]
+	if (!lock_zone(zone)) {
+		DEBUGERR("FAILED to lock zone: %p", zone);
+		return;
+	}
+	
+	// [zone のfreeマップの状態を変更する]
+	mark_chunk_as_free(zone, chunk);
+	// head ビットマップの状態は合体で変わるかもしれない
+
+	// [zone のフリーリストに chunk を挿入する]
+	DEBUGOUT("zone->frees: %p", zone->frees);
+	DEBUGOUT("chunk      : %p", chunk);
+	t_yoyo_chunk**	list = &(zone->frees);
+
+	while (true) {
+		t_yoyo_chunk*	head = ADDRESS_OF(*list);
+		DEBUGOUT("head: %p", head);
+		if (head == NULL) {
+			DEBUGOUT("PUSH BACK a chunk %p to %p", chunk, list);
+			break;
+		}
+		if ((uintptr_t)chunk < (uintptr_t)head) {
+			DEBUGOUT("PUSH FRONT a chunk %p of %p", chunk, list);
+			list = NULL;
+			break;
+		}
+		t_yoyo_chunk*	next = NEXT_OF(head);
+		if ((uintptr_t)chunk < (uintptr_t)next) {
+			DEBUGOUT("INSERT a chunk %p next of %p", chunk, list);
+			break;
+		}
+		list = &(head->next);
+	}
+	if (list == NULL) {
+		// PUSH FRONT
+		chunk->next = COPY_FLAGS(zone->frees, chunk->next);
+		list = &(zone->frees);
+	} else if (*list != NULL) {
+		// INSERT
+		chunk->next = COPY_FLAGS((*list)->next, chunk->next);
+	} else {
+		// PUSH BACK
+		chunk->next = COPY_FLAGS(NULL, chunk->next);
+	}
+	*list = chunk;
+
+	// [zone のblocks を変更する]
+	zone->blocks_free += chunk->blocks;
+	zone->blocks_used -= chunk->blocks;
+
+	// [zone のロックを離す]
+	if (!unlock_zone(zone)) {
+		DEBUGERR("FAILED to unlock zone: %p", zone);
+	}
+}
+
+
+void	actual_free(void* addr) {
+	t_yoyo_chunk*	chunk = addr;
+	--chunk;
+
+	if (IS_LARGE_CHUNK(chunk)) {
+		// TODO: LARGE chunk を解放する.
+		return;
+	}
+	// TINY / SMALL の解放処理
+	free_from_normal_zone(chunk);
+}

--- a/yoyo/srcs/yoyo_actual_free.c
+++ b/yoyo/srcs/yoyo_actual_free.c
@@ -1,7 +1,7 @@
 #include "yoyo_internal.h"
 
 
-static t_yoyo_zone*	get_zone_of_chunk(t_yoyo_chunk* chunk) {
+static t_yoyo_zone*	get_zone_of_chunk(const t_yoyo_chunk* chunk) {
 	const size_t whole_blocks = chunk->blocks;
 	assert(whole_blocks > 0);
 	const size_t usable_blocks = whole_blocks - 1;

--- a/yoyo/srcs/yoyo_actual_free.c
+++ b/yoyo/srcs/yoyo_actual_free.c
@@ -1,75 +1,79 @@
 #include "yoyo_internal.h"
 
 
-static void	free_from_normal_zone(t_yoyo_chunk* chunk) {
-	// [まず chunk が TINY / SMALL のどちらかを判定する]
-	// -> blocks から計算できるはず
+static t_yoyo_zone*	get_zone_of_chunk(t_yoyo_chunk* chunk) {
 	const size_t whole_blocks = chunk->blocks;
 	assert(whole_blocks > 0);
-	const size_t actual_blocks = whole_blocks - 1;
-	assert(actual_blocks > 0);
-	t_yoyo_zone_class zone_class = zone_class_for_bytes(actual_blocks * BLOCK_UNIT_SIZE);
-	DEBUGOUT("zone_class is %d", zone_class);
-	assert(zone_class != YOYO_ZONE_LARGE);
+	const size_t usable_blocks = whole_blocks - 1;
+	assert(usable_blocks > 0);
 
-	// [対応する zone に飛ぶ]
-	uintptr_t zone_mask = ~((zone_class == YOYO_ZONE_TINY ? ZONE_TINY_BYTE : ZONE_SMALL_BYTE) - 1);
-	DEBUGOUT("zone_mask is %lx", zone_mask);
-	t_yoyo_zone*	zone = (t_yoyo_zone*)((uintptr_t)chunk & zone_mask);
+	const t_yoyo_zone_type zone_type = zone_type_for_bytes(usable_blocks * BLOCK_UNIT_SIZE);
+	DEBUGOUT("zone_type is %d", zone_type);
+	assert(zone_type != YOYO_ZONE_LARGE);
+
+	const uintptr_t zone_addr_mask = ~((zone_type == YOYO_ZONE_TINY ? ZONE_TINY_BYTE : ZONE_SMALL_BYTE) - 1);
+	DEBUGOUT("zone_addr_mask is %lx", zone_addr_mask);
+	return (t_yoyo_zone*)((uintptr_t)chunk & zone_addr_mask);
+}
+
+static void insert_chunk_to_tiny_small_zone(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
+	DEBUGOUT("zone->frees: %p", zone->frees);
+	DEBUGOUT("chunk      : %p", chunk);
+	t_yoyo_chunk**	current_lot = &(zone->frees);
+
+	while (true) {
+		t_yoyo_chunk*	head = ADDRESS_OF(*current_lot);
+		DEBUGOUT("head: %p", head);
+		if (head == NULL) {
+			DEBUGOUT("PUSH BACK a chunk %p to %p", chunk, current_lot);
+			break;
+		}
+		if ((uintptr_t)chunk < (uintptr_t)head) {
+			DEBUGOUT("PUSH FRONT a chunk %p of %p", chunk, current_lot);
+			current_lot = NULL;
+			break;
+		}
+		t_yoyo_chunk*	next = NEXT_OF(head);
+		if ((uintptr_t)chunk < (uintptr_t)next) {
+			DEBUGOUT("INSERT a chunk %p next of %p", chunk, current_lot);
+			break;
+		}
+		current_lot = &(head->next);
+	}
+	if (current_lot == NULL) {
+		// PUSH FRONT
+		chunk->next = COPY_FLAGS(zone->frees, chunk->next);
+		current_lot = &(zone->frees);
+	} else if (*current_lot != NULL) {
+		// INSERT
+		chunk->next = COPY_FLAGS((*current_lot)->next, chunk->next);
+	} else {
+		// PUSH BACK
+		chunk->next = COPY_FLAGS(NULL, chunk->next);
+	}
+	*current_lot = chunk;
+}
+
+static void	free_from_tiny_small_zone(t_yoyo_chunk* chunk) {
+	// chunk の所属 zone に飛ぶ
+	t_yoyo_zone*	zone = get_zone_of_chunk(chunk);
 	DEBUGOUT("zone: %p", zone);
-
 	// [ロックを取る]
 	if (!lock_zone(zone)) {
 		DEBUGERR("FAILED to lock zone: %p", zone);
 		return;
 	}
-	
+	print_zone_state(zone);
 	// [zone のfreeマップの状態を変更する]
 	mark_chunk_as_free(zone, chunk);
 	// head ビットマップの状態は合体で変わるかもしれない
-
 	// [zone のフリーリストに chunk を挿入する]
-	DEBUGOUT("zone->frees: %p", zone->frees);
-	DEBUGOUT("chunk      : %p", chunk);
-	t_yoyo_chunk**	list = &(zone->frees);
-
-	while (true) {
-		t_yoyo_chunk*	head = ADDRESS_OF(*list);
-		DEBUGOUT("head: %p", head);
-		if (head == NULL) {
-			DEBUGOUT("PUSH BACK a chunk %p to %p", chunk, list);
-			break;
-		}
-		if ((uintptr_t)chunk < (uintptr_t)head) {
-			DEBUGOUT("PUSH FRONT a chunk %p of %p", chunk, list);
-			list = NULL;
-			break;
-		}
-		t_yoyo_chunk*	next = NEXT_OF(head);
-		if ((uintptr_t)chunk < (uintptr_t)next) {
-			DEBUGOUT("INSERT a chunk %p next of %p", chunk, list);
-			break;
-		}
-		list = &(head->next);
-	}
-	if (list == NULL) {
-		// PUSH FRONT
-		chunk->next = COPY_FLAGS(zone->frees, chunk->next);
-		list = &(zone->frees);
-	} else if (*list != NULL) {
-		// INSERT
-		chunk->next = COPY_FLAGS((*list)->next, chunk->next);
-	} else {
-		// PUSH BACK
-		chunk->next = COPY_FLAGS(NULL, chunk->next);
-	}
-	*list = chunk;
-
+	insert_chunk_to_tiny_small_zone(zone, chunk);
 	// [zone のblocks を変更する]
 	zone->blocks_free += chunk->blocks;
 	zone->blocks_used -= chunk->blocks;
-
 	// [zone のロックを離す]
+	print_zone_state(zone);
 	if (!unlock_zone(zone)) {
 		DEBUGERR("FAILED to unlock zone: %p", zone);
 	}
@@ -133,6 +137,10 @@ static void	free_from_large_zone(t_yoyo_chunk* chunk) {
 }
 
 void	actual_free(void* addr) {
+	if (addr == NULL) {
+		DEBUGSTR("addr is NULL; DO NOTHING");
+		return;
+	}
 	t_yoyo_chunk*	chunk = addr - CEILED_CHUNK_SIZE;
 
 	if (IS_LARGE_CHUNK(chunk)) {
@@ -141,5 +149,5 @@ void	actual_free(void* addr) {
 		return;
 	}
 	// TINY / SMALL の解放処理
-	free_from_normal_zone(chunk);
+	free_from_tiny_small_zone(chunk);
 }

--- a/yoyo/srcs/yoyo_actual_free.c
+++ b/yoyo/srcs/yoyo_actual_free.c
@@ -64,6 +64,7 @@ static void	free_from_tiny_small_zone(t_yoyo_chunk* chunk) {
 		return;
 	}
 	print_zone_state(zone);
+	print_zone_bitmap_state(zone);
 	// [zone のfreeマップの状態を変更する]
 	mark_chunk_as_free(zone, chunk);
 	// head ビットマップの状態は合体で変わるかもしれない
@@ -74,6 +75,7 @@ static void	free_from_tiny_small_zone(t_yoyo_chunk* chunk) {
 	zone->blocks_used -= chunk->blocks;
 	// [zone のロックを離す]
 	print_zone_state(zone);
+	print_zone_bitmap_state(zone);
 	if (!unlock_zone(zone)) {
 		DEBUGERR("FAILED to unlock zone: %p", zone);
 	}

--- a/yoyo/srcs/yoyo_actual_malloc.c
+++ b/yoyo/srcs/yoyo_actual_malloc.c
@@ -101,23 +101,6 @@ static void	zone_push_front(t_yoyo_zone** list, t_yoyo_zone* zone) {
 	*list = zone;
 }
 
-// このブロックが chunk のヘッダかどうか
-static bool	is_head(const t_yoyo_zone* zone, unsigned int block_index) {
-	unsigned int	byte_index = block_index / 8;
-	unsigned int	bit_index = block_index % 8;
-	unsigned char*	heads = (void*)zone + zone->offset_bitmap_heads;
-	return !!(heads[byte_index] & (1 << bit_index));
-}
-
-// このブロックがヘッダになっている chunk が使用中かどうか
-static bool	is_used(const t_yoyo_zone* zone, unsigned int block_index) {
-	unsigned int	byte_index = block_index / 8;
-	unsigned int	bit_index = block_index % 8;
-	unsigned char*	used = (void*)zone + zone->offset_bitmap_used;
-	return !!(used[byte_index] & (1 << bit_index));
-}
-
-
 // blocks_needed 要求されているとき, chunk を分割することで要求に応えられるか?
 static bool	is_separatable(const t_yoyo_chunk* chunk, size_t blocks_needed) {
 	assert(chunk->blocks > 1);
@@ -201,8 +184,10 @@ static void*	allocate_memory_from_zone_list(t_yoyo_arena* arena, t_yoyo_zone_typ
 		if (try_lock_zone(current_zone)) {
 			// zone ロックが取れた -> アロケートを試みる
 			print_zone_state(current_zone);
+			print_zone_bitmap_state(current_zone);
 			void*	mem = try_allocate_chunk_from_zone(current_zone, n);
 			print_zone_state(current_zone);
+			print_zone_bitmap_state(current_zone);
 			unlock_zone(current_zone);
 			if (mem != NULL) {
 				return mem;

--- a/yoyo/srcs/yoyo_actual_malloc.c
+++ b/yoyo/srcs/yoyo_actual_malloc.c
@@ -1,39 +1,42 @@
 #include "yoyo_internal.h"
 
-// ロックされた arena を1つ返す.
-static t_yoyo_arena*	occupy_arena(t_yoyo_zone_class zone_class) {
-	t_yoyo_arena* arena = NULL;
+// arena を1つロックして返す.
+// どの arena もロックできなかった場合は NULL を返す.
+static t_yoyo_arena*	occupy_arena(t_yoyo_zone_type zone_type) {
+	// まず trylock でロックできるか試してみる
 	for (unsigned int i = 0; i < g_yoyo_realm.arena_count; ++i) {
-		arena = &g_yoyo_realm.arenas[i];
-		if (try_lock_arena(arena, zone_class)) {
+		t_yoyo_arena*	arena = &g_yoyo_realm.arenas[i];
+		if (try_lock_arena(arena, zone_type)) {
 			DEBUGOUT("locked arenas[%u]", i);
-			break;
+			return arena;
 		}
-		arena = NULL;
 	}
-	if (arena == NULL) {
-		arena = &g_yoyo_realm.arenas[0];
-		if (!lock_arena(arena, zone_class)) {
-			return NULL;
-		}
+	// trylock できなかった場合はデフォルトの arena がロックできるまで待つ.
+	t_yoyo_arena*	default_arena = &g_yoyo_realm.arenas[0];
+	if (lock_arena(default_arena, zone_type)) {
 		DEBUGOUT("locked arenas[%u]", 0);
+		return default_arena;
 	}
-	return arena;
+	// このエラーは致命傷
+	DEBUGERR("%s", "COULDN'T LOCK any arena");
+	return NULL;
 }
 
-// LARGE chunk を mmap でアロケートする.
-static t_yoyo_large_chunk*	map_large_chunk(t_yoyo_large_arena* subarena, size_t n) {
-# define CEILED_LARGE_CHUNK_SIZE CEIL_BY(sizeof(t_yoyo_large_chunk), BLOCK_UNIT_SIZE)
-	const size_t		blocks_needed = BLOCKS_FOR_SIZE(n);
-	const size_t		usable_size = blocks_needed * BLOCK_UNIT_SIZE;
-	const size_t		mem_size = LARGE_OFFSET_USABLE + usable_size;
-	t_yoyo_large_chunk*	large_chunk = map_memory(mem_size);
+// LARGE chunk を mmap でアロケートして返す.
+// mmap が失敗した場合は NULL を返す.
+static t_yoyo_large_chunk*	allocate_large_chunk(t_yoyo_large_arena* subarena, size_t bytes) {
+	// まず mmap する.
+	const size_t		blocks_needed = BLOCKS_FOR_SIZE(bytes);
+	const size_t		bytes_usable = blocks_needed * BLOCK_UNIT_SIZE;
+	const size_t		bytes_large_chunk = LARGE_OFFSET_USABLE + bytes_usable;
+	t_yoyo_large_chunk*	large_chunk = map_memory(bytes_large_chunk);
 	if (large_chunk == NULL) {
-		DEBUGERR("failed for %zuB", n);
+		DEBUGERR("FAILED for %zuB", bytes);
 		return NULL;
 	}
+	// 初期化する.
 	large_chunk->subarena = subarena;
-	large_chunk->memory_byte = mem_size;
+	large_chunk->memory_byte = bytes_large_chunk;
 	large_chunk->large_next = NULL;
 	t_yoyo_chunk*		chunk = (void*)large_chunk + CEILED_LARGE_CHUNK_SIZE;
 	chunk->next = SET_FLAGS(NULL, YOYO_FLAG_LARGE);
@@ -41,45 +44,53 @@ static t_yoyo_large_chunk*	map_large_chunk(t_yoyo_large_arena* subarena, size_t 
 	return large_chunk;
 }
 
-// LARGE chunk をアロケートし, subarena に接続し, 使用可能領域のアドレスを返す.
-static void*	allocate_from_large(t_yoyo_large_arena* subarena, size_t n) {
-	t_yoyo_large_chunk*	large_chunk = map_large_chunk(subarena, n);
-	if (large_chunk == NULL) { return NULL; }
-	t_yoyo_large_chunk**	list = &(subarena->allocated);
-
-	while (true) {
-		t_yoyo_large_chunk*	head = *list;
+// LARGE subarena の使用中リストに LARGE chunk を接続する.
+static void	insert_large_chunk_to_subarena(
+	t_yoyo_large_arena* subarena,
+	t_yoyo_large_chunk* large_chunk
+) {
+	t_yoyo_large_chunk**	current_lot = &(subarena->allocated);
+	while (*current_lot != NULL) {
+		t_yoyo_large_chunk*	head = *current_lot;
 		DEBUGOUT("head: %p", head);
 		if (head == NULL) {
-			DEBUGOUT("PUSH BACK a chunk %p to %p", large_chunk, list);
+			DEBUGOUT("PUSH BACK a chunk %p to %p", large_chunk, current_lot);
 			break;
 		}
 		if ((uintptr_t)large_chunk < (uintptr_t)head) {
-			DEBUGOUT("PUSH FRONT a chunk %p of %p", large_chunk, list);
-			list = NULL;
+			DEBUGOUT("PUSH FRONT a chunk %p of %p", large_chunk, current_lot);
+			current_lot = NULL;
 			break;
 		}
 		t_yoyo_large_chunk*	next = head->large_next;
 		if ((uintptr_t)large_chunk < (uintptr_t)next) {
-			DEBUGOUT("INSERT a chunk %p next of %p", large_chunk, list);
+			DEBUGOUT("INSERT a chunk %p next of %p", large_chunk, current_lot);
 			break;
 		}
-		list = &(head->large_next);
+		current_lot = &(head->large_next);
 	}
-	if (list == NULL) {
+	if (current_lot == NULL) {
 		// PUSH FRONT
 		large_chunk->large_next = subarena->allocated;
-		list = &(subarena->allocated);
-	} else if (*list != NULL) {
+		current_lot = &(subarena->allocated);
+	} else if (*current_lot != NULL) {
 		// INSERT
-		large_chunk->large_next = (*list)->large_next;
+		large_chunk->large_next = (*current_lot)->large_next;
 	} else {
 		// PUSH BACK
 		large_chunk->large_next = NULL;
 	}
-	*list = large_chunk;
-	DEBUGOUT("subarena: %p", subarena);
-	DEBUGOUT("subarena->allocated: %p", subarena->allocated);
+	*current_lot = large_chunk;
+}
+
+// LARGE chunk をアロケートし, それを subarena に接続してから, 使用可能領域のアドレスを返す.
+// どこかの過程で失敗した場合は NULL を返す.
+static void*	allocate_memory_from_large(t_yoyo_large_arena* subarena, size_t n) {
+	// LARGE chunk をアロケートする.
+	t_yoyo_large_chunk*	large_chunk = allocate_large_chunk(subarena, n);
+	if (large_chunk == NULL) { return NULL; }
+	// アロケートした LARGE chunk を subarena のリストに接続する.
+	insert_large_chunk_to_subarena(subarena, large_chunk);
 	// 使用可能領域を返す
 	return (void*)large_chunk + LARGE_OFFSET_USABLE;
 }
@@ -120,8 +131,8 @@ static bool	is_separatable(const t_yoyo_chunk* chunk, size_t blocks_needed) {
 		DEBUGOUT("yes : %zu >= %zu", whole_rest, whole_needed);
 		return true;
 	}
-	t_yoyo_zone_class needed_class = zone_class_for_bytes(blocks_needed * BLOCK_UNIT_SIZE);
-	t_yoyo_zone_class needed_rest = zone_class_for_bytes((whole_rest - 1) * BLOCK_UNIT_SIZE);
+	t_yoyo_zone_type needed_class = zone_type_for_bytes(blocks_needed * BLOCK_UNIT_SIZE);
+	t_yoyo_zone_type needed_rest = zone_type_for_bytes((whole_rest - 1) * BLOCK_UNIT_SIZE);
 	if (needed_class != needed_rest) {
 		DEBUGOUT("no: not enough rest blocks: %zu < %zu", chunk->blocks, whole_needed);
 		return false;
@@ -138,9 +149,8 @@ static bool	is_exhaustible(const t_yoyo_chunk* chunk, size_t blocks_needed) {
 }
 
 // zone からサイズ n の chunk を取得しようとする.
-static void*	try_allocate_from_zone(t_yoyo_zone* zone, size_t n) {
+static void*	try_allocate_chunk_from_zone(t_yoyo_zone* zone, size_t n) {
 	DEBUGOUT("try from: %p - %zu", zone, n);
-
 	const size_t	blocks_needed = BLOCKS_FOR_SIZE(n);
 	DEBUGOUT("blocks needed: %zu, rest: %u", blocks_needed, zone->blocks_free);
 	const size_t	whole_needed = blocks_needed + 1;
@@ -148,98 +158,100 @@ static void*	try_allocate_from_zone(t_yoyo_zone* zone, size_t n) {
 		DEBUGWARN("no enough blocks in this zone: %u", zone->blocks_free);
 		return NULL;
 	}
-	t_yoyo_chunk**	list = &zone->frees;
-	while (*list != NULL) {
-		t_yoyo_chunk*	head = ADDRESS_OF(*list);
-		unsigned int	bi = get_block_index(zone, head);
+	t_yoyo_chunk**	current_lot = &zone->frees;
+	while (*current_lot != NULL) {
+		t_yoyo_chunk*	current_free_chunk = ADDRESS_OF(*current_lot);
+		unsigned int	bi = get_block_index(zone, current_free_chunk);
 		(void)bi;
 		assert(is_head(zone, bi));
 		assert(!is_used(zone, bi));
-		if (is_exhaustible(head, blocks_needed)) {
-			// head をすべて使用中にする.
+		if (is_exhaustible(current_free_chunk, blocks_needed)) {
+			// current_free_chunk をすべて使用中にする.
 			DEBUGSTR("EXHAUSTIBLE");
-			*list = head->next;
-			mark_chunk_as_used(zone, head);
-			zone->blocks_free -= head->blocks;
-			zone->blocks_used += head->blocks;
-			return (void*)head + BLOCK_UNIT_SIZE;
+			*current_lot = current_free_chunk->next;
+			mark_chunk_as_used(zone, current_free_chunk);
+			zone->blocks_free -= current_free_chunk->blocks;
+			zone->blocks_used += current_free_chunk->blocks;
+			return (void*)current_free_chunk + BLOCK_UNIT_SIZE;
 		}
-		if (is_separatable(head, blocks_needed)) {
-			// head の先頭を分離して blocks_needed + 1 の使用中ブロックを生成する.
+		if (is_separatable(current_free_chunk, blocks_needed)) {
+			// current_free_chunk の先頭を分離して blocks_needed + 1 の使用中ブロックを生成する.
 			DEBUGSTR("SEPARATABLE");
-			t_yoyo_chunk*	rest = (void*)head + whole_needed * BLOCK_UNIT_SIZE;
-			rest->blocks = head->blocks - whole_needed;
-			head->blocks = whole_needed;
-			rest->next = head->next;
-			*list = COPY_FLAGS(rest, head->next);
+			t_yoyo_chunk*	rest = (void*)current_free_chunk + whole_needed * BLOCK_UNIT_SIZE;
+			rest->blocks = current_free_chunk->blocks - whole_needed;
+			current_free_chunk->blocks = whole_needed;
+			rest->next = current_free_chunk->next;
+			*current_lot = COPY_FLAGS(rest, current_free_chunk->next);
 			mark_chunk_as_free(zone, rest);
-			mark_chunk_as_used(zone, head);
+			mark_chunk_as_used(zone, current_free_chunk);
 			zone->blocks_free -= whole_needed;
 			zone->blocks_used += whole_needed;
-			return (void*)head + BLOCK_UNIT_SIZE;
+			return (void*)current_free_chunk + BLOCK_UNIT_SIZE;
 		}
-		list = &(head->next);
+		current_lot = &(current_free_chunk->next);
 	}
 	DEBUGWARN("FAILED from: %p - %zuB", zone, n);
 	return NULL;
 }
 
-static void*	allocate_from_zone_list(t_yoyo_arena* arena, t_yoyo_zone_class zone_class, size_t n) {
-	t_yoyo_normal_arena* subarena = (t_yoyo_normal_arena*)get_subarena(arena, zone_class);
-	t_yoyo_zone*	head = subarena->head;
-	while (head != NULL) {
-		if (try_lock_zone(head)) {
+static void*	allocate_memory_from_zone_list(t_yoyo_arena* arena, t_yoyo_zone_type zone_type, size_t n) {
+	t_yoyo_normal_arena* subarena = (t_yoyo_normal_arena*)get_subarena(arena, zone_type);
+	t_yoyo_zone*	current_zone = subarena->head;
+	while (current_zone != NULL) {
+		if (try_lock_zone(current_zone)) {
 			// zone ロックが取れた -> アロケートを試みる
-			void*	mem = try_allocate_from_zone(head, n);
-			unlock_zone(head);
+			print_zone_state(current_zone);
+			void*	mem = try_allocate_chunk_from_zone(current_zone, n);
+			print_zone_state(current_zone);
+			unlock_zone(current_zone);
 			if (mem != NULL) {
 				return mem;
 			}
 		}
 		// zone ロックを取らないオペレーションは, 既存の zone の next をいじらないので,
 		// zone ロックを取らなくても zone->next を触っていいはず. たぶん.
-		head = head->next;
+		current_zone = current_zone->next;
 	}
 
 	// どの zone からもアロケートできなかった -> zone を増やしてもう一度
 	DEBUGWARN("ALLOCATE A ZONE NEWLY for %zuB", n);
-	t_yoyo_zone*	new_zone = allocate_zone(arena, zone_class);
+	t_yoyo_zone*	new_zone = allocate_zone(arena, zone_type);
 	if (new_zone == NULL) {
 		return NULL;
 	}
 	zone_push_front(&subarena->head, new_zone);
 
 	// new_zone はロック取らなくていい.
-	return try_allocate_from_zone(new_zone, n);
+	return try_allocate_chunk_from_zone(new_zone, n);
 }
 
-static void*	allocate_from_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class, size_t n) {
-	if (zone_class == YOYO_ZONE_LARGE) {
+static void*	allocate_from_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type, size_t n) {
+	if (zone_type == YOYO_ZONE_LARGE) {
 		// LARGE からアロケートする
-		return allocate_from_large(&arena->large, n);
+		return allocate_memory_from_large(&arena->large, n);
 	}
 	// TINY / SMALL からアロケートする
-	t_yoyo_subarena* subarena = get_subarena(arena, zone_class);
+	t_yoyo_subarena* subarena = get_subarena(arena, zone_type);
 	assert(subarena != NULL);
 	assert((void*)subarena != (void*)&arena->large);
-	return allocate_from_zone_list(arena, zone_class, n);
+	return allocate_memory_from_zone_list(arena, zone_type, n);
 }
 
 void*	actual_malloc(size_t n) {
 	// ゾーン種別決定
-	t_yoyo_zone_class zone_class = zone_class_for_bytes(n);
+	t_yoyo_zone_type zone_type = zone_type_for_bytes(n);
 
 	// 対応するアリーナを選択してロックする
-	t_yoyo_arena* arena = occupy_arena(zone_class);
+	t_yoyo_arena* arena = occupy_arena(zone_type);
 	if (arena == NULL) {
 		DEBUGWARN("%s", "failed: couldn't lock any arena");
 		return NULL;
 	}
 
-	void*	mem = allocate_from_arena(arena, zone_class, n);
+	void*	mem = allocate_from_arena(arena, zone_type, n);
 
 	// アンロックする
-	unlock_arena(arena, zone_class);
+	unlock_arena(arena, zone_type);
 	return mem;
 }
 

--- a/yoyo/srcs/yoyo_actual_malloc.c
+++ b/yoyo/srcs/yoyo_actual_malloc.c
@@ -117,6 +117,7 @@ void*	try_allocate_from_zone(t_yoyo_zone* zone, size_t n) {
 		}
 		list = &head->next;
 	}
+	DEBUGWARN("FAILED from: %p - %zuB", zone, n);
 	return NULL;
 }
 
@@ -124,7 +125,7 @@ void*	allocate_from_zone_list(t_yoyo_arena* arena, t_yoyo_zone_class zone_class,
 	t_yoyo_normal_arena* subarena = (t_yoyo_normal_arena*)get_subarena(arena, zone_class);
 	t_yoyo_zone*	head = subarena->head;
 	while (head != NULL) {
-		if (lock_zone(head)) {
+		if (try_lock_zone(head)) {
 			// zone ロックが取れた -> アロケートを試みる
 			void*	mem = try_allocate_from_zone(head, n);
 			unlock_zone(head);
@@ -138,6 +139,7 @@ void*	allocate_from_zone_list(t_yoyo_arena* arena, t_yoyo_zone_class zone_class,
 	}
 
 	// どの zone からもアロケートできなかった -> zone を増やしてもう一度
+	DEBUGWARN("ALLOCATE ZONE NEWLY for %zuB", n);
 	t_yoyo_zone*	new_zone = allocate_zone(arena, zone_class);
 	if (new_zone == NULL) {
 		return NULL;

--- a/yoyo/srcs/yoyo_actual_malloc.c
+++ b/yoyo/srcs/yoyo_actual_malloc.c
@@ -31,7 +31,7 @@ static t_yoyo_large_chunk*	allocate_large_chunk(t_yoyo_large_arena* subarena, si
 	const size_t		bytes_large_chunk = LARGE_OFFSET_USABLE + bytes_usable;
 	t_yoyo_large_chunk*	large_chunk = map_memory(bytes_large_chunk);
 	if (large_chunk == NULL) {
-		DEBUGERR("FAILED for %zuB", bytes);
+		DEBUGERR("FAILED for %zu B", bytes);
 		return NULL;
 	}
 	// 初期化する.
@@ -173,7 +173,7 @@ static void*	try_allocate_chunk_from_zone(t_yoyo_zone* zone, size_t n) {
 		}
 		current_lot = &(current_free_chunk->next);
 	}
-	DEBUGWARN("FAILED from: %p - %zuB", zone, n);
+	DEBUGWARN("FAILED from: %p - %zu B", zone, n);
 	return NULL;
 }
 
@@ -199,7 +199,7 @@ static void*	allocate_memory_from_zone_list(t_yoyo_arena* arena, t_yoyo_zone_typ
 	}
 
 	// どの zone からもアロケートできなかった -> zone を増やしてもう一度
-	DEBUGWARN("ALLOCATE A ZONE NEWLY for %zuB", n);
+	DEBUGWARN("ALLOCATE A ZONE NEWLY for %zu B", n);
 	t_yoyo_zone*	new_zone = allocate_zone(arena, zone_type);
 	if (new_zone == NULL) {
 		return NULL;

--- a/yoyo/srcs/yoyo_actual_malloc.c
+++ b/yoyo/srcs/yoyo_actual_malloc.c
@@ -1,0 +1,6 @@
+#include "yoyo_internal.h"
+
+// void	yoyo_actual_malloc(size_t n) {
+
+// }
+

--- a/yoyo/srcs/yoyo_actual_malloc.c
+++ b/yoyo/srcs/yoyo_actual_malloc.c
@@ -1,6 +1,100 @@
 #include "yoyo_internal.h"
 
-// void	yoyo_actual_malloc(size_t n) {
+// ロックされた arena を1つ返す.
+static t_yoyo_arena*	occupy_arena(t_yoyo_zone_class zone_class) {
+	t_yoyo_arena* arena = NULL;
+	for (unsigned int i = 0; i < g_yoyo_realm.arena_count; ++i) {
+		arena = &g_yoyo_realm.arenas[i];
+		if (try_lock_arena(arena, zone_class)) {
+			DEBUGOUT("locked arenas[%u]", i);
+			break;
+		}
+		arena = NULL;
+	}
+	if (arena == NULL) {
+		arena = &g_yoyo_realm.arenas[0];
+		if (!lock_arena(arena, zone_class)) {
+			return NULL;
+		}
+		DEBUGOUT("locked arenas[%u]", 0);
+	}
+	return arena;
+}
 
-// }
+// stub
+void*	allocate_from_large(t_yoyo_large_arena* subarena, size_t n) {
+	(void)subarena;
+	(void)n;
+	assert(false);
+	return NULL;
+}
+
+static void	zone_push_front(t_yoyo_zone** list, t_yoyo_zone* zone) {
+	assert(list != NULL);
+	zone->next = *list;
+	*list = zone;
+}
+
+// zone からサイズ n の chunk を取得しようとする.
+void*	try_allocate_from_zone(t_yoyo_zone* zone, size_t n) {
+	(void)zone;
+	(void)n;
+	DEBUGOUT("try from: %p - %zu", zone, n);
+	return NULL;
+}
+
+void*	allocate_from_zone_list(t_yoyo_arena* arena, t_yoyo_zone_class zone_class, size_t n) {
+	t_yoyo_normal_arena* subarena = (t_yoyo_normal_arena*)get_subarena(arena, zone_class);
+	t_yoyo_zone*	head = subarena->head;
+	while (head != NULL) {
+		if (lock_zone(head)) {
+			// zone ロックが取れた -> アロケートを試みる
+			void*	mem = try_allocate_from_zone(head, n);
+			unlock_zone(head);
+			if (mem != NULL) {
+				return mem;
+			}
+		}
+		// zone ロックを取らないオペレーションは, 既存の zone の next をいじらないので,
+		// zone ロックを取らなくても zone->next を触っていいはず. たぶん.
+		head = head->next;
+	}
+	// どの zone からもアロケートできなかった -> zone を増やしてもう一度
+	t_yoyo_zone*	new_zone = allocate_zone(arena, zone_class);
+	if (new_zone == NULL) {
+		return NULL;
+	}
+	zone_push_front(&subarena->head, new_zone);
+	// new_zone はロック取らなくていい.
+	return try_allocate_from_zone(new_zone, n);
+}
+
+void*	allocate_from_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class, size_t n) {
+	if (zone_class == YOYO_ZONE_LARGE) {
+		return allocate_from_large(&arena->large, n);
+	}
+	// TINY / SMALL からアロケートする
+	t_yoyo_subarena* subarena = get_subarena(arena, zone_class);
+	assert(subarena != NULL);
+	assert((void*)subarena != (void*)&arena->large);
+	return allocate_from_zone_list(arena, zone_class, n);
+}
+
+void*	actual_malloc(size_t n) {
+	// ゾーン種別決定
+	t_yoyo_zone_class zone_class = zone_class_for_bytes(n);
+
+	// 対応するアリーナを選択してロックする
+	t_yoyo_arena* arena = occupy_arena(zone_class);
+	if (arena == NULL) {
+		DEBUGWARN("%s", "failed: couldn't lock any arena");
+		return NULL;
+	}
+
+	void*	mem = allocate_from_arena(arena, zone_class, n);
+
+	// アンロックする
+	unlock_arena(arena, zone_class);
+	return mem;
+}
 

--- a/yoyo/srcs/yoyo_actual_malloc.c
+++ b/yoyo/srcs/yoyo_actual_malloc.c
@@ -51,9 +51,10 @@ static void	insert_large_chunk_to_subarena(
 ) {
 	t_yoyo_large_chunk**	current_lot = &(subarena->allocated);
 	t_yoyo_large_chunk*		front = NULL;
+	(void)front;
 
 	// [挿入場所を見つける]
-	while (*current_lot != NULL) {
+	while (true) {
 		t_yoyo_large_chunk*	back = *current_lot;
 		DEBUGOUT("front: %p, back: %p", front, back);
 		if (back == NULL) {
@@ -159,6 +160,8 @@ static void*	try_allocate_chunk_from_zone(t_yoyo_zone* zone, size_t n) {
 			mark_chunk_as_used(zone, current_free_chunk);
 			zone->blocks_free -= whole_needed;
 			zone->blocks_used += whole_needed;
+			print_zone_state(zone);
+			print_zone_bitmap_state(zone);
 			return (void*)current_free_chunk + BLOCK_UNIT_SIZE;
 		}
 		current_lot = &(current_free_chunk->next);

--- a/yoyo/srcs/yoyo_actual_realloc.c
+++ b/yoyo/srcs/yoyo_actual_realloc.c
@@ -1,0 +1,98 @@
+#include "yoyo_internal.h"
+
+static void	*yoyo_memcpy(void* dst, const void* src, size_t n) {
+	unsigned char*			ud;
+	const unsigned char*	us;
+
+	ud = dst;
+	us = src;
+	while (n--)
+		*ud++ = *us++;
+	return dst;
+}
+
+// 最低 blocks_required ブロックあるチャンクを新しく確保し,
+// 使用中チャンク chunk の内容をそこにコピーし,
+// chunk を解放する.
+static void*	relocate_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
+	// [引っ越し先チャンクを確保]
+	DEBUGINFO("%s", "ALLOCATE");
+	void*	relocated = actual_malloc((blocks_required - 1) * BLOCK_UNIT_SIZE);
+	if (relocated == NULL) {
+		return NULL;
+	}
+	// [データをコピー]
+	DEBUGINFO("%s", "COPY");
+	t_yoyo_chunk*	chunk_relocated = relocated - CEILED_CHUNK_SIZE;
+	const size_t	blocks_copy = (chunk_relocated->blocks < chunk->blocks) ? chunk_relocated->blocks : chunk->blocks;
+	void*			addr_current = (void*)chunk + CEILED_CHUNK_SIZE;
+	yoyo_memcpy(relocated, addr_current, blocks_copy * BLOCK_UNIT_SIZE);
+	// [現在のチャンクを解放]
+	DEBUGINFO("%s", "DEALLOCATE");
+	actual_free(addr_current);
+	return relocated;
+}
+
+// 使用中チャンク chunk を, 先頭アドレスを変えないで blocks_required ブロックに縮小し,
+// 残ったブロックからフリーチャンクを生成する.
+static void	shrink_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
+	DEBUGOUT("chunk->blocks: %zu", chunk->blocks);
+	assert(2 <= blocks_required);
+	assert(blocks_required < chunk->blocks);
+	t_yoyo_zone*	zone_current = get_zone_of_chunk(chunk);
+	if (zone_current == NULL) {
+		return;
+	}
+	t_yoyo_chunk*	chunk_new_free = (void *)chunk + blocks_required * BLOCK_UNIT_SIZE;
+	chunk_new_free->blocks = chunk->blocks - blocks_required;
+	chunk_new_free->next = COPY_FLAGS(NULL, chunk->next);
+	chunk->blocks = blocks_required;
+	actual_free((void*)chunk_new_free + CEILED_CHUNK_SIZE);
+	return;
+}
+
+// 実際の realloc の動作をする
+void*	actual_realloc(void* addr, size_t n) {
+	if (addr == NULL) {
+		DEBUGWARN("addr == NULL -> delegate to malloc(%zu)", n);
+		return actual_malloc(n);
+	}
+	assert(CEILED_CHUNK_SIZE <= (size_t)addr);
+	t_yoyo_chunk*	chunk = addr - CEILED_CHUNK_SIZE;
+
+	const size_t			blocks_required = BLOCKS_FOR_SIZE(n) + 1;
+	const size_t			blocks_current = chunk->blocks;
+	const t_yoyo_zone_type	type_required = zone_type_for_bytes(n);
+	const t_yoyo_zone_type	type_current = zone_type_for_bytes(blocks_current * BLOCK_UNIT_SIZE);
+
+	DEBUGOUT("blocks_required: %zu <? blocks_current: %zu", blocks_required, blocks_current);
+	// ゾーン種別が変わる場合は RELOCATE
+	if (type_required != type_current) {
+		DEBUGWARN("%s", "EXEC RELOCATE");
+		return relocate_chunk(chunk, blocks_required);
+	}
+	// SHRINK できるか？
+	// - 要求ブロックサイズ < 現在ブロックサイズ
+	// - 要求ゾーンタイプ = 現在ゾーンタイプ
+	// - 新しく生成されるフリーチャンクのブロックサイズが2以上
+	if (blocks_required < blocks_current) {
+		const size_t	blocks_new_free = blocks_current - blocks_required;
+		DEBUGOUT("blocks_new_free: %zu", blocks_new_free);
+		const t_yoyo_zone_type	type_new_free = zone_type_for_bytes(blocks_new_free * BLOCK_UNIT_SIZE);
+		if (blocks_new_free >= 2 && type_new_free == type_current) {
+			// SHRINK できる.
+			DEBUGWARN("%s", "EXEC SHRINK");
+			shrink_chunk(chunk, blocks_required);
+			return addr;
+		}
+	}
+	// MAINTAIN できるか？
+	// - 要求ブロックサイズ ≤ 現在ブロックサイズ
+	// - 要求ゾーンタイプ = 現在ゾーンタイプ
+	if (blocks_required <= blocks_current) {
+		DEBUGWARN("%s", "EXEC MAINTAIN");
+		return addr;
+	}
+	// RELOCATE
+	return relocate_chunk(chunk, blocks_required);
+}

--- a/yoyo/srcs/yoyo_actual_realloc.c
+++ b/yoyo/srcs/yoyo_actual_realloc.c
@@ -24,7 +24,7 @@ static void*	relocate_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
 	// [データをコピー]
 	DEBUGINFO("%s", "COPY");
 	t_yoyo_chunk*	chunk_relocated = relocated - CEILED_CHUNK_SIZE;
-	const size_t	blocks_copy = (chunk_relocated->blocks < chunk->blocks) ? chunk_relocated->blocks : chunk->blocks;
+	const size_t	blocks_copy = ((chunk_relocated->blocks < chunk->blocks) ? chunk_relocated->blocks : chunk->blocks) - 1;
 	void*			addr_current = (void*)chunk + CEILED_CHUNK_SIZE;
 	yoyo_memcpy(relocated, addr_current, blocks_copy * BLOCK_UNIT_SIZE);
 	// [現在のチャンクを解放]
@@ -45,8 +45,10 @@ static void	shrink_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
 	}
 	t_yoyo_chunk*	chunk_new_free = (void *)chunk + blocks_required * BLOCK_UNIT_SIZE;
 	chunk_new_free->blocks = chunk->blocks - blocks_required;
+	assert(2 <= chunk_new_free->blocks);
 	chunk_new_free->next = COPY_FLAGS(NULL, chunk->next);
 	chunk->blocks = blocks_required;
+	assert(2 <= chunk->blocks);
 	actual_free((void*)chunk_new_free + CEILED_CHUNK_SIZE);
 	return;
 }

--- a/yoyo/srcs/yoyo_arena_initialize.c
+++ b/yoyo/srcs/yoyo_arena_initialize.c
@@ -52,8 +52,8 @@ void	destroy_arena(t_yoyo_arena* arena) {
 	arena->initialized = false;
 }
 
-t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
-	switch (zone_class) {
+t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
+	switch (zone_type) {
 		case YOYO_ZONE_TINY:
 			return (t_yoyo_subarena*)&arena->tiny;
 		case YOYO_ZONE_SMALL:

--- a/yoyo/srcs/yoyo_arena_initialize.c
+++ b/yoyo/srcs/yoyo_arena_initialize.c
@@ -1,0 +1,48 @@
+#include "yoyo_internal.h"
+
+// [arena の初期化に使う関数]
+
+// arena を初期化する.
+// multi_thread が true ならマルチスレッドモードとして初期化を行い, mutex を作成する.
+// mutex の作成に失敗した場合は false を返す.
+bool	init_arena(t_yoyo_arena* arena, bool multi_thread) {
+	if (multi_thread) {
+		if (pthread_mutex_init(&arena->tiny.lock, NULL)) {
+			DEBUGERR("failed to init tiny lock: errno: %d (%s)", errno, strerror(errno));
+			return false;
+		}
+		if (pthread_mutex_init(&arena->small.lock, NULL)) {
+			DEBUGERR("failed to init small lock: errno: %d (%s)", errno, strerror(errno));
+			pthread_mutex_destroy(&arena->tiny.lock);
+			return false;
+		}
+		if (pthread_mutex_init(&arena->large.lock, NULL)) {
+			DEBUGERR("failed to init large lock: errno: %d (%s)", errno, strerror(errno));
+			pthread_mutex_destroy(&arena->tiny.lock);
+			pthread_mutex_destroy(&arena->small.lock);
+			return false;
+		}
+	}
+	arena->initialized = true;
+	arena->tiny.head = NULL;
+	arena->small.head = NULL;
+	arena->large.head = NULL;
+	DEBUGINFO("initialized arena: %p, multi_thread: %s", arena, multi_thread ? "y" : "n");
+	return true;
+}
+
+// 初期化済みの arena を実初期化に戻す.
+// 普通は使わないはず.
+void	destroy_arena(t_yoyo_arena* arena) {
+	if (!arena->initialized) {
+		DEBUGWARN("skip: arena %p is not intialized", arena);
+		return;
+	}
+	if (arena->multi_thread) {
+		pthread_mutex_destroy(&arena->tiny.lock);
+		pthread_mutex_destroy(&arena->small.lock);
+		pthread_mutex_destroy(&arena->tiny.lock);
+	}
+	arena->initialized = false;
+}
+

--- a/yoyo/srcs/yoyo_arena_initialize.c
+++ b/yoyo/srcs/yoyo_arena_initialize.c
@@ -52,7 +52,7 @@ void	destroy_arena(t_yoyo_arena* arena) {
 	arena->initialized = false;
 }
 
-t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
+t_yoyo_subarena*	get_subarena(const t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
 	switch (zone_type) {
 		case YOYO_ZONE_TINY:
 			return (t_yoyo_subarena*)&arena->tiny;

--- a/yoyo/srcs/yoyo_arena_initialize.c
+++ b/yoyo/srcs/yoyo_arena_initialize.c
@@ -23,6 +23,7 @@ bool	init_arena(t_yoyo_arena* arena, bool multi_thread) {
 			return false;
 		}
 	}
+	arena->multi_thread = multi_thread;
 	arena->initialized = true;
 	arena->tiny.head = NULL;
 	arena->small.head = NULL;

--- a/yoyo/srcs/yoyo_arena_initialize.c
+++ b/yoyo/srcs/yoyo_arena_initialize.c
@@ -29,7 +29,7 @@ bool	init_arena(unsigned int index, bool multi_thread) {
 	arena->initialized = true;
 	arena->tiny.head = NULL;
 	arena->small.head = NULL;
-	arena->large.head = NULL;
+	arena->large.allocated = NULL;
 	DEBUGINFO("initialized arena: #%u(%p), multi_thread: %s", index, arena, multi_thread ? "y" : "n");
 	return true;
 }
@@ -52,10 +52,10 @@ void	destroy_arena(t_yoyo_arena* arena) {
 t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	switch (zone_class) {
 		case YOYO_ZONE_TINY:
-			return &arena->tiny;
+			return (t_yoyo_subarena*)&arena->tiny;
 		case YOYO_ZONE_SMALL:
-			return &arena->small;
+			return (t_yoyo_subarena*)&arena->small;
 		case YOYO_ZONE_LARGE:
-			return &arena->large;
+			return (t_yoyo_subarena*)&arena->large;
 	}
 }

--- a/yoyo/srcs/yoyo_arena_initialize.c
+++ b/yoyo/srcs/yoyo_arena_initialize.c
@@ -5,7 +5,8 @@
 // arena を初期化する.
 // multi_thread が true ならマルチスレッドモードとして初期化を行い, mutex を作成する.
 // mutex の作成に失敗した場合は false を返す.
-bool	init_arena(t_yoyo_arena* arena, bool multi_thread) {
+bool	init_arena(unsigned int index, bool multi_thread) {
+	t_yoyo_arena* arena = &g_yoyo_realm.arenas[index];
 	if (multi_thread) {
 		if (pthread_mutex_init(&arena->tiny.lock, NULL)) {
 			DEBUGERR("failed to init tiny lock: errno: %d (%s)", errno, strerror(errno));
@@ -23,12 +24,13 @@ bool	init_arena(t_yoyo_arena* arena, bool multi_thread) {
 			return false;
 		}
 	}
+	arena->index = index;
 	arena->multi_thread = multi_thread;
 	arena->initialized = true;
 	arena->tiny.head = NULL;
 	arena->small.head = NULL;
 	arena->large.head = NULL;
-	DEBUGINFO("initialized arena: %p, multi_thread: %s", arena, multi_thread ? "y" : "n");
+	DEBUGINFO("initialized arena: #%u(%p), multi_thread: %s", index, arena, multi_thread ? "y" : "n");
 	return true;
 }
 
@@ -47,3 +49,13 @@ void	destroy_arena(t_yoyo_arena* arena) {
 	arena->initialized = false;
 }
 
+t_yoyo_subarena*	get_subarena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+	switch (zone_class) {
+		case YOYO_ZONE_TINY:
+			return &arena->tiny;
+		case YOYO_ZONE_SMALL:
+			return &arena->small;
+		case YOYO_ZONE_LARGE:
+			return &arena->large;
+	}
+}

--- a/yoyo/srcs/yoyo_arena_initialize.c
+++ b/yoyo/srcs/yoyo_arena_initialize.c
@@ -28,8 +28,11 @@ bool	init_arena(unsigned int index, bool multi_thread) {
 	arena->multi_thread = multi_thread;
 	arena->initialized = true;
 	arena->tiny.head = NULL;
+	arena->tiny.multi_thread = multi_thread;
 	arena->small.head = NULL;
+	arena->small.multi_thread = multi_thread;
 	arena->large.allocated = NULL;
+	arena->large.multi_thread = multi_thread;
 	DEBUGINFO("initialized arena: #%u(%p), multi_thread: %s", index, arena, multi_thread ? "y" : "n");
 	return true;
 }

--- a/yoyo/srcs/yoyo_arena_initialize.c
+++ b/yoyo/srcs/yoyo_arena_initialize.c
@@ -32,7 +32,7 @@ bool	init_arena(t_yoyo_arena* arena, bool multi_thread) {
 	return true;
 }
 
-// 初期化済みの arena を実初期化に戻す.
+// 初期化済みの arena を未初期化に戻す.
 // 普通は使わないはず.
 void	destroy_arena(t_yoyo_arena* arena) {
 	if (!arena->initialized) {

--- a/yoyo/srcs/yoyo_debug.c
+++ b/yoyo/srcs/yoyo_debug.c
@@ -3,9 +3,46 @@
 // zone の状態を出力する.
 // ロックは必要なら取っておくこと.
 void	print_zone_state(const t_yoyo_zone* zone) {
-	DEBUGOUT(
+	DEBUGINFO(
 		"ZONE %p: MT: %s, class: %d, blocks: zone %u, heap %u, free %u, used %u",
 		zone, zone->multi_thread ? "Y" : "N",
 		zone->zone_type, zone->blocks_zone, zone->blocks_heap, zone->blocks_free, zone->blocks_used
 	);
+}
+
+// zone のビットマップの統計情報を出力する
+// ロックは必要なら取っておくこと.
+void	print_zone_bitmap_state(const t_yoyo_zone* zone) {
+	unsigned int n_head = 0;
+	unsigned int n_used = 0;
+	for (unsigned int i = 0; i < zone->blocks_heap; ++i) {
+		const bool h = is_head(zone, i);
+		n_head += !!h;
+		n_used += !!(h && is_used(zone, i));
+	}
+	DEBUGINFO(
+		"ZONE %p: MT: %s, class: %d, is_head: %u, is_used: %u",
+		zone, zone->multi_thread ? "Y" : "N", zone->zone_type,
+		n_head, n_used
+	);
+}
+
+// addr が malloc が返した領域であると仮定して, 情報を出力する
+// ロックは必要なら取っておくこと.
+void	print_memory_state(const void* addr) {
+	const t_yoyo_chunk*	chunk = addr - CEILED_CHUNK_SIZE;
+	if (IS_LARGE_CHUNK(chunk)) {
+		// chunk is LARGE
+		const t_yoyo_large_chunk* large_chunk = (void*)chunk - CEILED_LARGE_CHUNK_SIZE;
+		DEBUGINFO(
+			"chunk at %p is LARGE: %p, subarena: %p, total bytes: %zuB",
+			addr, large_chunk, large_chunk->subarena, large_chunk->memory_byte
+		);
+	} else {
+		// chunk is TINY / SMALL
+		DEBUGINFO(
+			"chunk at %p: %p, blocks: %zu",
+			addr, chunk, chunk->blocks
+		);
+	}
 }

--- a/yoyo/srcs/yoyo_debug.c
+++ b/yoyo/srcs/yoyo_debug.c
@@ -35,7 +35,7 @@ void	print_memory_state(const void* addr) {
 		// chunk is LARGE
 		const t_yoyo_large_chunk* large_chunk = (void*)chunk - CEILED_LARGE_CHUNK_SIZE;
 		DEBUGINFO(
-			"chunk at %p is LARGE: %p, subarena: %p, total bytes: %zuB",
+			"chunk at %p is LARGE: %p, subarena: %p, total bytes: %zu B",
 			addr, large_chunk, large_chunk->subarena, large_chunk->memory_byte
 		);
 	} else {

--- a/yoyo/srcs/yoyo_debug.c
+++ b/yoyo/srcs/yoyo_debug.c
@@ -1,0 +1,11 @@
+#include "yoyo_internal.h"
+
+// zone の状態を出力する.
+// ロックは必要なら取っておくこと.
+void	print_zone_state(const t_yoyo_zone* zone) {
+	DEBUGOUT(
+		"ZONE %p: MT: %s, class: %d, blocks: zone %u, heap %u, free %u, used %u",
+		zone, zone->multi_thread ? "Y" : "N",
+		zone->zone_type, zone->blocks_zone, zone->blocks_heap, zone->blocks_free, zone->blocks_used
+	);
+}

--- a/yoyo/srcs/yoyo_lock.c
+++ b/yoyo/srcs/yoyo_lock.c
@@ -43,6 +43,19 @@ bool	lock_zone(t_yoyo_zone* zone) {
 	return true;
 }
 
+bool	try_lock_zone(t_yoyo_zone* zone) {
+	if (!zone->multi_thread) {
+		DEBUGOUT("skip: in single-thread mode: %p", zone);
+		return true;
+	}
+	if (pthread_mutex_trylock(&zone->lock)) {
+		DEBUGERR("failed to try lock: %d(%s)", errno, strerror(errno));
+		return false;
+	}
+	DEBUGOUT("locked: %p", zone);
+	return true;
+}
+
 bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	if (!arena->multi_thread) {
 		DEBUGOUT("skip: in single-thread mode: #%u(%p)", arena->index, arena);

--- a/yoyo/srcs/yoyo_lock.c
+++ b/yoyo/srcs/yoyo_lock.c
@@ -2,40 +2,31 @@
 
 // [ロックを取る/解除する]
 
-static t_yoyo_subarena* get_subarena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
-	switch (zone_class) {
-		case YOYO_ZONE_TINY:
-			return &arena->tiny;
-		case YOYO_ZONE_SMALL:
-			return &arena->small;
-		case YOYO_ZONE_LARGE:
-			return &arena->large;
-	}
-}
-
 bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	if (!arena->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: %p", arena);
+		DEBUGOUT("skip: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
 	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
-	if (!pthread_mutex_lock(&subarena->lock)) {
+	if (pthread_mutex_lock(&subarena->lock)) {
 		DEBUGERR("failed to lock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
+	DEBUGOUT("locked: #%u(%p)", arena->index, arena);
 	return true;
 }
 
 bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	if (!arena->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: %p", arena);
+		DEBUGOUT("skip: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
 	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
-	if (!pthread_mutex_trylock(&subarena->lock)) {
+	if (pthread_mutex_trylock(&subarena->lock)) {
 		DEBUGERR("failed to try lock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
+	DEBUGOUT("locked: #%u(%p)", arena->index, arena);
 	return true;
 }
 
@@ -44,23 +35,25 @@ bool	lock_zone(t_yoyo_zone* zone) {
 		DEBUGOUT("skip: in single-thread mode: %p", zone);
 		return true;
 	}
-	if (!pthread_mutex_lock(&zone->lock)) {
+	if (pthread_mutex_lock(&zone->lock)) {
 		DEBUGERR("failed to lock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
+	DEBUGOUT("locked: %p", zone);
 	return true;
 }
 
 bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	if (!arena->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: %p", arena);
+		DEBUGOUT("skip: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
 	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
-	if (!pthread_mutex_unlock(&subarena->lock)) {
+	if (pthread_mutex_unlock(&subarena->lock)) {
 		DEBUGERR("failed to unlock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
+	DEBUGOUT("unlocked: #%u(%p)", arena->index, arena);
 	return true;	
 }
 
@@ -69,9 +62,10 @@ bool	unlock_zone(t_yoyo_zone* zone) {
 		DEBUGOUT("skip: in single-thread mode: %p", zone);
 		return true;
 	}
-	if (!pthread_mutex_unlock(&zone->lock)) {
+	if (pthread_mutex_unlock(&zone->lock)) {
 		DEBUGERR("failed to unlock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
+	DEBUGOUT("unlocked: %p", zone);
 	return true;
 }

--- a/yoyo/srcs/yoyo_lock.c
+++ b/yoyo/srcs/yoyo_lock.c
@@ -1,0 +1,77 @@
+#include "yoyo_internal.h"
+
+// [ロックを取る/解除する]
+
+static t_yoyo_subarena* get_subarena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+	switch (zone_class) {
+		case YOYO_ZONE_TINY:
+			return &arena->tiny;
+		case YOYO_ZONE_SMALL:
+			return &arena->small;
+		case YOYO_ZONE_LARGE:
+			return &arena->large;
+	}
+}
+
+bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+	if (!arena->multi_thread) {
+		DEBUGOUT("skip: in single-thread mode: %p", arena);
+		return true;
+	}
+	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
+	if (!pthread_mutex_lock(&subarena->lock)) {
+		DEBUGERR("failed to lock: %d(%s)", errno, strerror(errno));
+		return false;
+	}
+	return true;
+}
+
+bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+	if (!arena->multi_thread) {
+		DEBUGOUT("skip: in single-thread mode: %p", arena);
+		return true;
+	}
+	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
+	if (!pthread_mutex_trylock(&subarena->lock)) {
+		DEBUGERR("failed to try lock: %d(%s)", errno, strerror(errno));
+		return false;
+	}
+	return true;
+}
+
+bool	lock_zone(t_yoyo_zone* zone) {
+	if (!zone->multi_thread) {
+		DEBUGOUT("skip: in single-thread mode: %p", zone);
+		return true;
+	}
+	if (!pthread_mutex_lock(&zone->lock)) {
+		DEBUGERR("failed to lock: %d(%s)", errno, strerror(errno));
+		return false;
+	}
+	return true;
+}
+
+bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+	if (!arena->multi_thread) {
+		DEBUGOUT("skip: in single-thread mode: %p", arena);
+		return true;
+	}
+	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
+	if (!pthread_mutex_unlock(&subarena->lock)) {
+		DEBUGERR("failed to unlock: %d(%s)", errno, strerror(errno));
+		return false;
+	}
+	return true;	
+}
+
+bool	unlock_zone(t_yoyo_zone* zone) {
+	if (!zone->multi_thread) {
+		DEBUGOUT("skip: in single-thread mode: %p", zone);
+		return true;
+	}
+	if (!pthread_mutex_unlock(&zone->lock)) {
+		DEBUGERR("failed to unlock: %d(%s)", errno, strerror(errno));
+		return false;
+	}
+	return true;
+}

--- a/yoyo/srcs/yoyo_lock.c
+++ b/yoyo/srcs/yoyo_lock.c
@@ -4,81 +4,81 @@
 
 bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	if (!arena->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: #%u(%p)", arena->index, arena);
+		DEBUGOUT("SKIP: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
 	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
 	if (pthread_mutex_lock(&subarena->lock)) {
-		DEBUGERR("failed to lock: %d(%s)", errno, strerror(errno));
+		DEBUGERR("FAILED to lock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
-	DEBUGOUT("locked: #%u(%p)", arena->index, arena);
+	DEBUGOUT("LOCKED: #%u(%p)", arena->index, arena);
 	return true;
 }
 
 bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	if (!arena->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: #%u(%p)", arena->index, arena);
+		DEBUGOUT("SKIP: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
 	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
 	if (pthread_mutex_trylock(&subarena->lock)) {
-		DEBUGERR("failed to try lock: %d(%s)", errno, strerror(errno));
+		DEBUGERR("FAILED to try lock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
-	DEBUGOUT("locked: #%u(%p)", arena->index, arena);
+	DEBUGOUT("LOCKED: #%u(%p)", arena->index, arena);
 	return true;
 }
 
 bool	lock_zone(t_yoyo_zone* zone) {
 	if (!zone->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: %p", zone);
+		DEBUGOUT("SKIP: in single-thread mode: %p", zone);
 		return true;
 	}
 	if (pthread_mutex_lock(&zone->lock)) {
-		DEBUGERR("failed to lock: %d(%s)", errno, strerror(errno));
+		DEBUGERR("FAILED to lock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
-	DEBUGOUT("locked: %p", zone);
+	DEBUGOUT("LOCKED: %p", zone);
 	return true;
 }
 
 bool	try_lock_zone(t_yoyo_zone* zone) {
 	if (!zone->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: %p", zone);
+		DEBUGOUT("SKIP: in single-thread mode: %p", zone);
 		return true;
 	}
 	if (pthread_mutex_trylock(&zone->lock)) {
-		DEBUGERR("failed to try lock: %d(%s)", errno, strerror(errno));
+		DEBUGERR("FAILED to try lock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
-	DEBUGOUT("locked: %p", zone);
+	DEBUGOUT("LOCKED: %p", zone);
 	return true;
 }
 
 bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	if (!arena->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: #%u(%p)", arena->index, arena);
+		DEBUGOUT("SKIP: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
 	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
 	if (pthread_mutex_unlock(&subarena->lock)) {
-		DEBUGERR("failed to unlock: %d(%s)", errno, strerror(errno));
+		DEBUGERR("FAILED to unlock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
-	DEBUGOUT("unlocked: #%u(%p)", arena->index, arena);
+	DEBUGOUT("UNLOCKED: #%u(%p)", arena->index, arena);
 	return true;	
 }
 
 bool	unlock_zone(t_yoyo_zone* zone) {
 	if (!zone->multi_thread) {
-		DEBUGOUT("skip: in single-thread mode: %p", zone);
+		DEBUGOUT("SKIP: in single-thread mode: %p", zone);
 		return true;
 	}
 	if (pthread_mutex_unlock(&zone->lock)) {
-		DEBUGERR("failed to unlock: %d(%s)", errno, strerror(errno));
+		DEBUGERR("FAILED to unlock: %d(%s)", errno, strerror(errno));
 		return false;
 	}
-	DEBUGOUT("unlocked: %p", zone);
+	DEBUGOUT("UNLOCKED: %p", zone);
 	return true;
 }

--- a/yoyo/srcs/yoyo_lock.c
+++ b/yoyo/srcs/yoyo_lock.c
@@ -2,12 +2,12 @@
 
 // [ロックを取る/解除する]
 
-bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
 	if (!arena->multi_thread) {
 		DEBUGOUT("SKIP: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
-	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
+	t_yoyo_subarena*	subarena = get_subarena(arena, zone_type);
 	if (!lock_subarena(subarena)) {
 		DEBUGERR("FAILED to lock: %d(%s)", errno, strerror(errno));
 		return false;
@@ -16,12 +16,12 @@ bool	lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	return true;
 }
 
-bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+bool	try_lock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
 	if (!arena->multi_thread) {
 		DEBUGOUT("SKIP: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
-	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
+	t_yoyo_subarena*	subarena = get_subarena(arena, zone_type);
 	if (!try_lock_subarena(subarena)) {
 		DEBUGERR("FAILED to try lock: %d(%s)", errno, strerror(errno));
 		return false;
@@ -82,12 +82,12 @@ bool	try_lock_zone(t_yoyo_zone* zone) {
 	return true;
 }
 
-bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+bool	unlock_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
 	if (!arena->multi_thread) {
 		DEBUGOUT("SKIP: in single-thread mode: #%u(%p)", arena->index, arena);
 		return true;
 	}
-	t_yoyo_subarena*	subarena = get_subarena(arena, zone_class);
+	t_yoyo_subarena*	subarena = get_subarena(arena, zone_type);
 	if (pthread_mutex_unlock(&subarena->lock)) {
 		DEBUGERR("FAILED to unlock: %d(%s)", errno, strerror(errno));
 		return false;

--- a/yoyo/srcs/yoyo_malloc.c
+++ b/yoyo/srcs/yoyo_malloc.c
@@ -1,0 +1,12 @@
+#include "yoyo_malloc.h"
+
+void*	yoyo_malloc(size_t n) {
+	return malloc(n);
+}
+
+void	yoyo_free(void* addr) {
+	free(addr);
+}
+void*	yoyo_realloc(void* addr, size_t n) {
+	return realloc(addr, n);
+}

--- a/yoyo/srcs/yoyo_malloc.c
+++ b/yoyo/srcs/yoyo_malloc.c
@@ -1,5 +1,6 @@
 #include "yoyo_malloc.h"
 
+
 void*	yoyo_malloc(size_t n) {
 	return malloc(n);
 }

--- a/yoyo/srcs/yoyo_malloc.c
+++ b/yoyo/srcs/yoyo_malloc.c
@@ -27,3 +27,11 @@ void*	yoyo_realloc(void* addr, size_t n) {
 	DEBUGSTR("** realloc end **");
 	return mem;
 }
+
+void	show_alloc_mem(void) {
+	DEBUGSTR("** show_alloc_mem **");
+	SPRINT_START;
+	actual_show_alloc_mem();
+	SPRINT_END("realloc");
+	DEBUGSTR("** realloc end **");
+}

--- a/yoyo/srcs/yoyo_malloc.c
+++ b/yoyo/srcs/yoyo_malloc.c
@@ -1,8 +1,14 @@
 #include "yoyo_malloc.h"
+#include "yoyo_internal.h"
 
 
 void*	yoyo_malloc(size_t n) {
-	return malloc(n);
+	DEBUGOUT("** bytes: %zu **", n);
+	SPRINT_START;
+	void	*mem = actual_malloc(n);
+	SPRINT_END("malloc");
+	DEBUGSTR("** malloc end **");
+	return mem;
 }
 
 void	yoyo_free(void* addr) {

--- a/yoyo/srcs/yoyo_malloc.c
+++ b/yoyo/srcs/yoyo_malloc.c
@@ -12,8 +12,13 @@ void*	yoyo_malloc(size_t n) {
 }
 
 void	yoyo_free(void* addr) {
-	free(addr);
+	DEBUGOUT("** addr: %p **", addr);
+	SPRINT_START;
+	actual_free(addr);
+	SPRINT_END("free");
+	DEBUGSTR("** free end **");
 }
+
 void*	yoyo_realloc(void* addr, size_t n) {
 	return realloc(addr, n);
 }

--- a/yoyo/srcs/yoyo_malloc.c
+++ b/yoyo/srcs/yoyo_malloc.c
@@ -20,5 +20,10 @@ void	yoyo_free(void* addr) {
 }
 
 void*	yoyo_realloc(void* addr, size_t n) {
-	return realloc(addr, n);
+	DEBUGOUT("** addr: %p, n: %zu **", addr, n);
+	SPRINT_START;
+	void*	mem = actual_realloc(addr, n);
+	SPRINT_END("realloc");
+	DEBUGSTR("** realloc end **");
+	return mem;
 }

--- a/yoyo/srcs/yoyo_memory_alloc.c
+++ b/yoyo/srcs/yoyo_memory_alloc.c
@@ -32,3 +32,7 @@ void*	allocate_aligned_memory(size_t bytes) {
 	assert(((uintptr_t)mem & ((uintptr_t)bytes - 1)) == 0); // mem は bytes アラインされている
 	return mem;
 }
+
+void	deallocate_memory(void* start, size_t size) {
+	unmap_range(start, start + size);
+}

--- a/yoyo/srcs/yoyo_memory_alloc.c
+++ b/yoyo/srcs/yoyo_memory_alloc.c
@@ -1,0 +1,34 @@
+#include "yoyo_internal.h"
+
+static void	unmap_range(void* begin, void* end) {
+	if((size_t)begin >= (size_t)end) {
+		DEBUGOUT("skipped: [%p, %p)", begin, end);
+		return;
+	}
+	if (munmap(begin, (size_t)end - (size_t)begin)) {
+		DEBUGERR("FAILED: errno = %d, %s", errno, strerror(errno));
+		return;
+	}
+	DEBUGOUT("unmapped: [%p, %p) (%zd)", begin, end, end - begin);
+}
+
+// bytes バイトの領域を mmap して返す.
+// 領域は bytes バイトアラインされる.
+void*	allocate_aligned_memory(size_t bytes) {
+	assert((bytes & (bytes - 1)) == 0); // bytes は 2冪である
+	void	*bulk = mmap(
+		NULL,
+		bytes * 2,
+		PROT_READ | PROT_WRITE,
+		MAP_ANON | MAP_PRIVATE,
+		-1, 0);
+	if (bulk == MAP_FAILED) {
+		return NULL;
+	}
+	void*	mem = (void*)CEIL_BY((size_t)bulk, bytes);
+	void*	end = mem + bytes;
+	unmap_range(bulk, mem);
+	unmap_range(end, bulk + bytes * 2);
+	assert(((uintptr_t)mem & ((uintptr_t)bytes - 1)) == 0); // mem は bytes アラインされている
+	return mem;
+}

--- a/yoyo/srcs/yoyo_memory_alloc.c
+++ b/yoyo/srcs/yoyo_memory_alloc.c
@@ -39,16 +39,16 @@ void*	map_memory(size_t bytes) {
 		return NULL;
 	}
 	if (should_align) {
-		DEBUGOUT("aligning region %p(%zuB) to %zuB", bulk, bulk_size, bytes);
+		DEBUGOUT("aligning region %p(%zu B) to %zu B", bulk, bulk_size, bytes);
 		void*	mem = (void*)CEIL_BY((size_t)bulk, bytes);
 		void*	end = mem + bytes;
 		unmap_range(bulk, mem);
 		unmap_range(end, bulk + bytes * 2);
 		assert(((uintptr_t)mem & ((uintptr_t)bytes - 1)) == 0); // mem は bytes アラインされている
-		DEBUGOUT("returning aligned region %p(%zuB)", mem, bytes);
+		DEBUGOUT("returning aligned region %p(%zu B)", mem, bytes);
 		return mem;
 	} else {
-		DEBUGOUT("returning bulk region %p(%zuB)", bulk, bulk_size);
+		DEBUGOUT("returning bulk region %p(%zu B)", bulk, bulk_size);
 		return bulk;
 	}
 }

--- a/yoyo/srcs/yoyo_memory_alloc.c
+++ b/yoyo/srcs/yoyo_memory_alloc.c
@@ -19,15 +19,17 @@ static void	unmap_range(void* begin, void* end) {
 }
 
 // bytes バイトの領域を mmap して返す.
-// 領域は bytes バイトアラインされる.
-void*	allocate_memory(size_t bytes) {
-	assert((bytes & (bytes - 1)) == 0); // bytes は 2冪である
+// bytes が2冪なら, 領域は bytes バイトアラインされる.
+void*	map_memory(size_t bytes) {
+	const bool		should_align = ((bytes & (bytes - 1)) == 0);
+	const size_t	bulk_size = should_align ? 2 * bytes : bytes;
 	void*	bulk;
+
 	{
 		SPRINT_START;
 		bulk = mmap(
 			NULL,
-			bytes * 2,
+			bulk_size,
 			PROT_READ | PROT_WRITE,
 			MAP_ANON | MAP_PRIVATE,
 			-1, 0);
@@ -36,14 +38,21 @@ void*	allocate_memory(size_t bytes) {
 	if (bulk == MAP_FAILED) {
 		return NULL;
 	}
-	void*	mem = (void*)CEIL_BY((size_t)bulk, bytes);
-	void*	end = mem + bytes;
-	unmap_range(bulk, mem);
-	unmap_range(end, bulk + bytes * 2);
-	assert(((uintptr_t)mem & ((uintptr_t)bytes - 1)) == 0); // mem は bytes アラインされている
-	return mem;
+	if (should_align) {
+		DEBUGOUT("aligning region %p(%zuB) to %zuB", bulk, bulk_size, bytes);
+		void*	mem = (void*)CEIL_BY((size_t)bulk, bytes);
+		void*	end = mem + bytes;
+		unmap_range(bulk, mem);
+		unmap_range(end, bulk + bytes * 2);
+		assert(((uintptr_t)mem & ((uintptr_t)bytes - 1)) == 0); // mem は bytes アラインされている
+		DEBUGOUT("returning aligned region %p(%zuB)", mem, bytes);
+		return mem;
+	} else {
+		DEBUGOUT("returning bulk region %p(%zuB)", bulk, bulk_size);
+		return bulk;
+	}
 }
 
-void	deallocate_memory(void* start, size_t size) {
+void	unmap_memory(void* start, size_t size) {
 	unmap_range(start, start + size);
 }

--- a/yoyo/srcs/yoyo_memory_alloc.c
+++ b/yoyo/srcs/yoyo_memory_alloc.c
@@ -5,7 +5,13 @@ static void	unmap_range(void* begin, void* end) {
 		DEBUGOUT("skipped: [%p, %p)", begin, end);
 		return;
 	}
-	if (munmap(begin, (size_t)end - (size_t)begin)) {
+	int rv;
+	{
+		SPRINT_START;
+		rv = munmap(begin, (size_t)end - (size_t)begin);
+		SPRINT_END("munmap");
+	}
+	if (rv) {
 		DEBUGERR("FAILED: errno = %d, %s", errno, strerror(errno));
 		return;
 	}
@@ -16,12 +22,17 @@ static void	unmap_range(void* begin, void* end) {
 // 領域は bytes バイトアラインされる.
 void*	allocate_memory(size_t bytes) {
 	assert((bytes & (bytes - 1)) == 0); // bytes は 2冪である
-	void	*bulk = mmap(
-		NULL,
-		bytes * 2,
-		PROT_READ | PROT_WRITE,
-		MAP_ANON | MAP_PRIVATE,
-		-1, 0);
+	void*	bulk;
+	{
+		SPRINT_START;
+		bulk = mmap(
+			NULL,
+			bytes * 2,
+			PROT_READ | PROT_WRITE,
+			MAP_ANON | MAP_PRIVATE,
+			-1, 0);
+		SPRINT_END("mmap");
+	}
 	if (bulk == MAP_FAILED) {
 		return NULL;
 	}

--- a/yoyo/srcs/yoyo_memory_alloc.c
+++ b/yoyo/srcs/yoyo_memory_alloc.c
@@ -9,12 +9,12 @@ static void	unmap_range(void* begin, void* end) {
 		DEBUGERR("FAILED: errno = %d, %s", errno, strerror(errno));
 		return;
 	}
-	DEBUGOUT("unmapped: [%p, %p) (%zd)", begin, end, end - begin);
+	DEBUGOUT("unmapped: [%p, %p) (%zdB)", begin, end, end - begin);
 }
 
 // bytes バイトの領域を mmap して返す.
 // 領域は bytes バイトアラインされる.
-void*	allocate_aligned_memory(size_t bytes) {
+void*	allocate_memory(size_t bytes) {
 	assert((bytes & (bytes - 1)) == 0); // bytes は 2冪である
 	void	*bulk = mmap(
 		NULL,

--- a/yoyo/srcs/yoyo_realm_initialize.c
+++ b/yoyo/srcs/yoyo_realm_initialize.c
@@ -7,7 +7,7 @@ bool	init_realm(bool multi_thread) {
 	}
 	g_yoyo_realm.arena_count = multi_thread ? ARENA_MAX : 1;
 	for (unsigned int i = 0; i < g_yoyo_realm.arena_count; ++i) {
-		const bool ok = init_arena(&g_yoyo_realm.arenas[i], multi_thread);
+		const bool ok = init_arena(i, multi_thread);
 		if (!ok) {
 			for (unsigned int j = 0; j < i; ++j) {
 				destroy_arena(&g_yoyo_realm.arenas[j]);

--- a/yoyo/srcs/yoyo_realm_initialize.c
+++ b/yoyo/srcs/yoyo_realm_initialize.c
@@ -1,5 +1,14 @@
 #include "yoyo_internal.h"
 
+// n個までの arena を破棄する
+static void	destroy_n_arenas(unsigned int n) {
+	for (unsigned int i = 0; i < n; ++i) {
+		destroy_arena(&g_yoyo_realm.arenas[i]);
+	}
+}
+
+// realm を初期化する.
+// スタートアップルーチンから実行される前提.
 bool	init_realm(bool multi_thread) {
 	if (g_yoyo_realm.initialized) {
 		DEBUGWARN("%s", "skip: realm is already initialized.");
@@ -7,11 +16,10 @@ bool	init_realm(bool multi_thread) {
 	}
 	g_yoyo_realm.arena_count = multi_thread ? ARENA_MAX : 1;
 	for (unsigned int i = 0; i < g_yoyo_realm.arena_count; ++i) {
-		const bool ok = init_arena(i, multi_thread);
-		if (!ok) {
-			for (unsigned int j = 0; j < i; ++j) {
-				destroy_arena(&g_yoyo_realm.arenas[j]);
-			}
+		const bool succeeded = init_arena(i, multi_thread);
+		if (!succeeded) {
+			DEBUGERR("FAILED to init arena #%u", i);
+			destroy_n_arenas(i);
 			return false;
 		}
 	}

--- a/yoyo/srcs/yoyo_realm_initialize.c
+++ b/yoyo/srcs/yoyo_realm_initialize.c
@@ -1,0 +1,21 @@
+#include "yoyo_internal.h"
+
+bool	init_realm(bool multi_thread) {
+	if (g_yoyo_realm.initialized) {
+		DEBUGWARN("%s", "skip: realm is already initialized.");
+		return true;
+	}
+	g_yoyo_realm.arena_count = multi_thread ? ARENA_MAX : 1;
+	for (unsigned int i = 0; i < g_yoyo_realm.arena_count; ++i) {
+		const bool ok = init_arena(&g_yoyo_realm.arenas[i], multi_thread);
+		if (!ok) {
+			for (unsigned int j = 0; j < i; ++j) {
+				destroy_arena(&g_yoyo_realm.arenas[j]);
+			}
+			return false;
+		}
+	}
+	g_yoyo_realm.initialized = true;
+	DEBUGINFO("initialized realm: arena_count = %u, multi_thread: %s", g_yoyo_realm.arena_count, multi_thread ? "y" : "n");
+	return true;
+}

--- a/yoyo/srcs/yoyo_visualize.c
+++ b/yoyo/srcs/yoyo_visualize.c
@@ -1,0 +1,87 @@
+#include "yoyo_internal.h"
+
+extern t_yoyo_realm	g_yoyo_realm;
+
+static void	visualize_chunk(const t_yoyo_chunk* chunk) {
+	printf("\t\t\tchunk @ %p: %zu blocks (%zu B)\n", chunk, chunk->blocks, chunk->blocks * BLOCK_UNIT_SIZE);
+}
+
+// 指定した zone を可視化する
+static void	visualize_locked_zone(t_yoyo_zone* zone) {
+	printf("\t\t[zone: %p]\n", zone);
+	printf("\t\tusing %u blocks / %u blocks\n", zone->blocks_used, zone->blocks_zone);
+	// 使用中チャンクを表示していく
+	unsigned int	block_index = 0;
+	while (block_index < zone->blocks_heap) {
+		DEBUGOUT("block_index = %u", block_index);
+		t_yoyo_chunk*	chunk = get_chunk_by_index(zone, block_index);
+		if (chunk == NULL) { break; }
+		DEBUGOUT("chunk: %p", chunk);
+		DEBUGOUT("chunk->blocks: %zu", chunk->blocks);
+		DEBUGOUT("chunk->next: %p", chunk->next);
+		if (is_used(zone, block_index)) {
+			// 表示
+			visualize_chunk(chunk);
+		}
+		assert(2 <= chunk->blocks);
+		block_index += chunk->blocks;
+	}
+
+}
+
+// TINY / SMALL サブアリーナを, 配下の zone を順次ロックしながら可視化していく.
+static void	visualize_locked_tiny_small_subarena(const char* zone_name, t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
+	assert(zone_type == YOYO_ZONE_TINY || zone_type == YOYO_ZONE_SMALL);
+	t_yoyo_normal_arena* subarena = zone_type == YOYO_ZONE_TINY ? &arena->tiny : &arena->small;
+	if (subarena->head == NULL) {
+		return;
+	}
+	printf("\t< %s >\n", zone_name);
+	t_yoyo_zone*	zone = subarena->head;
+	size_t	n_zone = 0;
+	while (zone != NULL) {
+		if (!lock_zone(zone)) {
+			return;
+		}
+		visualize_locked_zone(zone);
+		t_yoyo_zone*	next = zone->next;
+		if (!unlock_zone(zone)) {
+			return;
+		}
+		zone = next;
+		n_zone += 1;
+	}
+	printf("\t%zu zones in this subarena\n", n_zone);
+}
+
+// 指定した subarena を可視化する
+static void	visualize_subarena(
+	const char* zone_name,
+	t_yoyo_arena* arena, t_yoyo_zone_type zone_type,
+	void (visualizer)(const char* zone_name, t_yoyo_arena*, t_yoyo_zone_type)
+) {
+	if (!lock_arena(arena, zone_type)) {
+		return;
+	}
+	visualizer(zone_name, arena, zone_type);
+	if (!unlock_arena(arena, zone_type)) {
+		return;
+	}
+}
+
+// 指定した arena を可視化する
+static void	visualize_arena(t_yoyo_arena* arena) {
+	printf("[arena #%u (%s)]\n", arena->index, arena->multi_thread ? "multi-thread mode" : "single-thread mode");
+	visualize_subarena("TINY", arena, YOYO_ZONE_TINY, visualize_locked_tiny_small_subarena);
+	visualize_subarena("SMALL", arena, YOYO_ZONE_SMALL, visualize_locked_tiny_small_subarena);
+}
+
+void	actual_show_alloc_mem(void) {
+	if (!g_yoyo_realm.initialized) {
+		DEBUGERR("%s", "REALM IS NOT INITIALIZED");
+		return;
+	}
+	for (unsigned int i = 0; i < g_yoyo_realm.arena_count; ++i) {
+		visualize_arena(&g_yoyo_realm.arenas[i]);
+	}
+}

--- a/yoyo/srcs/yoyo_visualize.c
+++ b/yoyo/srcs/yoyo_visualize.c
@@ -3,7 +3,7 @@
 extern t_yoyo_realm	g_yoyo_realm;
 
 static void	visualize_chunk(const t_yoyo_chunk* chunk) {
-	printf("\t\t\tchunk @ %p: %zu blocks (%zu B)\n", chunk, chunk->blocks, chunk->blocks * BLOCK_UNIT_SIZE);
+	printf("\t\tchunk @ %p: %zu blocks (%zu B)\n", chunk, chunk->blocks, chunk->blocks * BLOCK_UNIT_SIZE);
 }
 
 // 指定した zone を可視化する
@@ -13,12 +13,8 @@ static void	visualize_locked_zone(t_yoyo_zone* zone) {
 	// 使用中チャンクを表示していく
 	unsigned int	block_index = 0;
 	while (block_index < zone->blocks_heap) {
-		DEBUGOUT("block_index = %u", block_index);
 		t_yoyo_chunk*	chunk = get_chunk_by_index(zone, block_index);
 		if (chunk == NULL) { break; }
-		DEBUGOUT("chunk: %p", chunk);
-		DEBUGOUT("chunk->blocks: %zu", chunk->blocks);
-		DEBUGOUT("chunk->next: %p", chunk->next);
 		if (is_used(zone, block_index)) {
 			// 表示
 			visualize_chunk(chunk);
@@ -26,7 +22,6 @@ static void	visualize_locked_zone(t_yoyo_zone* zone) {
 		assert(2 <= chunk->blocks);
 		block_index += chunk->blocks;
 	}
-
 }
 
 // TINY / SMALL サブアリーナを, 配下の zone を順次ロックしながら可視化していく.
@@ -54,6 +49,32 @@ static void	visualize_locked_tiny_small_subarena(const char* zone_name, t_yoyo_a
 	printf("\t%zu zones in this subarena\n", n_zone);
 }
 
+static void	visualize_large_chunk(const t_yoyo_large_chunk* large_chunk) {
+	const t_yoyo_chunk* chunk = (void*)large_chunk + CEILED_LARGE_CHUNK_SIZE;
+	printf(
+		"\tlarge chunk @ %p: %zu B (usable: %zu B)\n",
+		large_chunk, large_chunk->memory_byte, chunk->blocks * BLOCK_UNIT_SIZE - CEILED_CHUNK_SIZE
+	);
+}
+
+// LARGE サブアリーナを可視化する
+static void	visualize_locked_large_subarena(const char* zone_name, t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
+	assert(zone_type == YOYO_ZONE_LARGE);
+	t_yoyo_large_arena* subarena = &arena->large;
+	if (subarena->allocated == NULL) {
+		return;
+	}
+	printf("\t< %s >\n", zone_name);
+	t_yoyo_large_chunk*	large_chunk = subarena->allocated;
+	size_t	n_large_chunk = 0;
+	while (large_chunk != NULL) {
+		visualize_large_chunk(large_chunk);
+		large_chunk = large_chunk->large_next;
+		n_large_chunk += 1;
+	}
+	printf("\t%zu large chunk in this subarena\n", n_large_chunk);
+}
+
 // 指定した subarena を可視化する
 static void	visualize_subarena(
 	const char* zone_name,
@@ -74,6 +95,7 @@ static void	visualize_arena(t_yoyo_arena* arena) {
 	printf("[arena #%u (%s)]\n", arena->index, arena->multi_thread ? "multi-thread mode" : "single-thread mode");
 	visualize_subarena("TINY", arena, YOYO_ZONE_TINY, visualize_locked_tiny_small_subarena);
 	visualize_subarena("SMALL", arena, YOYO_ZONE_SMALL, visualize_locked_tiny_small_subarena);
+	visualize_subarena("LARGE", arena, YOYO_ZONE_LARGE, visualize_locked_large_subarena);
 }
 
 void	actual_show_alloc_mem(void) {

--- a/yoyo/srcs/yoyo_zone_bitmap.c
+++ b/yoyo/srcs/yoyo_zone_bitmap.c
@@ -1,0 +1,17 @@
+#include "yoyo_internal.h"
+
+// このブロックが chunk のヘッダかどうか
+bool	is_head(const t_yoyo_zone* zone, unsigned int block_index) {
+	unsigned int	byte_index = block_index / 8;
+	unsigned int	bit_index = block_index % 8;
+	unsigned char*	heads = (void*)zone + zone->offset_bitmap_heads;
+	return !!(heads[byte_index] & (1 << bit_index));
+}
+
+// このブロックがヘッダになっている chunk が使用中かどうか
+bool	is_used(const t_yoyo_zone* zone, unsigned int block_index) {
+	unsigned int	byte_index = block_index / 8;
+	unsigned int	bit_index = block_index % 8;
+	unsigned char*	used = (void*)zone + zone->offset_bitmap_used;
+	return !!(used[byte_index] & (1 << bit_index));
+}

--- a/yoyo/srcs/yoyo_zone_bitmap.c
+++ b/yoyo/srcs/yoyo_zone_bitmap.c
@@ -16,3 +16,11 @@ bool	is_used(const t_yoyo_zone* zone, unsigned int block_index) {
 	return !!(used[byte_index] & (1 << bit_index));
 }
 
+// block_index に対応する位置に chunk ヘッダなら, それを返す.
+t_yoyo_chunk*	get_chunk_by_index(t_yoyo_zone* zone, unsigned int block_index) {
+	assert(block_index < zone->blocks_heap);
+	if (!is_head(zone, block_index)) {
+		return NULL;
+	}
+	return (void*)zone + zone->offset_heap + block_index * BLOCK_UNIT_SIZE;
+}

--- a/yoyo/srcs/yoyo_zone_bitmap.c
+++ b/yoyo/srcs/yoyo_zone_bitmap.c
@@ -15,3 +15,4 @@ bool	is_used(const t_yoyo_zone* zone, unsigned int block_index) {
 	unsigned char*	used = (void*)zone + zone->offset_bitmap_used;
 	return !!(used[byte_index] & (1 << bit_index));
 }
+

--- a/yoyo/srcs/yoyo_zone_initialize.c
+++ b/yoyo/srcs/yoyo_zone_initialize.c
@@ -17,28 +17,50 @@ size_t	bitmap_bytes_for_zone_bytes(size_t zone_bytes) {
 	return h / BLOCK_UNIT_SIZE / 8;
 }
 
+t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
+	const size_t zone_bytes = zone_bytes_for_zone_class(zone_class);
+	t_yoyo_zone* zone = allocate_aligned_memory(zone_bytes);
+	if (zone == NULL) {
+		DEBUGERR("failed for class: %d", zone_class);
+		return NULL;
+	}
+	DEBUGOUT("allocated %zu bytes region at %p", zone_bytes, zone);
+	if (!init_zone(arena, zone, zone_class)) {
+		deallocate_memory(zone, zone_bytes);
+		return NULL;
+	}
+	return zone;
+}
+
 // zone を初期化する.
 // 失敗した場合は false を返す.
-bool	init_zone(t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class zone_class) {
+bool	init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class zone_class) {
 	if (arena->multi_thread) {
 		if (pthread_mutex_init(&zone->lock, NULL)) {
 			DEBUGERR("errno: %d (%s)", errno, strerror(errno));
 			return false;
 		}
+		DEBUGOUT("%s", "@multi_thread");
 	}
 	zone->multi_thread = arena->multi_thread;
 	const size_t zone_bytes = zone_bytes_for_zone_class(zone_class);
 	const size_t heap_bytes = heap_bytes_for_zone_bytes(zone_bytes);
 	const size_t bitmap_bytes = bitmap_bytes_for_zone_bytes(zone_bytes);
+	DEBUGOUT("heap: %zuB bitmap: %zuB", heap_bytes, bitmap_bytes);
 	zone->next = NULL;
 	zone->frees = NULL;
 	zone->free_prev = NULL;
 	zone->blocks_zone = zone_bytes / BLOCK_UNIT_SIZE;
 	zone->blocks_heap = heap_bytes / BLOCK_UNIT_SIZE;
+	DEBUGOUT("blocks_zone: %u", zone->blocks_zone);
+	DEBUGOUT("blocks_heap: %u", zone->blocks_heap);
 	zone->blocks_free = zone->blocks_heap;
 	zone->blocks_used = 0;
 	zone->offset_bitmap_heads = sizeof(t_yoyo_zone);
 	zone->offset_bitmap_used = zone->offset_bitmap_heads + bitmap_bytes;
 	zone->offset_heap = zone_bytes - heap_bytes;
+	DEBUGOUT("offset_bitmap_heads: %uB", zone->offset_bitmap_heads);
+	DEBUGOUT("offset_bitmap_used:  %uB", zone->offset_bitmap_used);
+	DEBUGOUT("offset_heap:         %uB", zone->offset_heap);
 	return true;
 }

--- a/yoyo/srcs/yoyo_zone_initialize.c
+++ b/yoyo/srcs/yoyo_zone_initialize.c
@@ -1,0 +1,44 @@
+#include "yoyo_internal.h"
+
+// [zone の初期化時に使う関数]
+
+// zone 全体のバイト数から heap のバイト数を計算する.
+size_t	heap_bytes_for_zone_bytes(size_t zone_bytes) {
+	const size_t d = 4 * (zone_bytes - sizeof(t_yoyo_zone));
+	const size_t n = 4 * BLOCK_UNIT_SIZE + 1;
+	const size_t h = FLOOR_BY(d / n, 8);
+	printf("d = %zu, n = %zu, h = %zu\n", d, n, h);
+	return h * BLOCK_UNIT_SIZE;
+}
+
+// ビットマップフィールドのバイト数を計算する.
+size_t	bitmap_bytes_for_zone_bytes(size_t zone_bytes) {
+	const size_t h = heap_bytes_for_zone_bytes(zone_bytes);
+	return h / BLOCK_UNIT_SIZE / 8;
+}
+
+// zone を初期化する.
+// 失敗した場合は false を返す.
+bool	init_zone(t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class zone_class) {
+	if (arena->multi_thread) {
+		if (pthread_mutex_init(&zone->lock, NULL)) {
+			DEBUGERR("errno: %d (%s)", errno, strerror(errno));
+			return false;
+		}
+	}
+	zone->multi_thread = arena->multi_thread;
+	const size_t zone_bytes = zone_bytes_for_zone_class(zone_class);
+	const size_t heap_bytes = heap_bytes_for_zone_bytes(zone_bytes);
+	const size_t bitmap_bytes = bitmap_bytes_for_zone_bytes(zone_bytes);
+	zone->next = NULL;
+	zone->frees = NULL;
+	zone->free_prev = NULL;
+	zone->blocks_zone = zone_bytes / BLOCK_UNIT_SIZE;
+	zone->blocks_heap = heap_bytes / BLOCK_UNIT_SIZE;
+	zone->blocks_free = zone->blocks_heap;
+	zone->blocks_used = 0;
+	zone->offset_bitmap_heads = sizeof(t_yoyo_zone);
+	zone->offset_bitmap_used = zone->offset_bitmap_heads + bitmap_bytes;
+	zone->offset_heap = zone_bytes - heap_bytes;
+	return true;
+}

--- a/yoyo/srcs/yoyo_zone_initialize.c
+++ b/yoyo/srcs/yoyo_zone_initialize.c
@@ -19,7 +19,7 @@ size_t	bitmap_bytes_for_zone_bytes(size_t zone_bytes) {
 
 t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_class zone_class) {
 	const size_t zone_bytes = zone_bytes_for_zone_class(zone_class);
-	t_yoyo_zone* zone = allocate_aligned_memory(zone_bytes);
+	t_yoyo_zone* zone = allocate_memory(zone_bytes);
 	if (zone == NULL) {
 		DEBUGERR("failed for class: %d", zone_class);
 		return NULL;

--- a/yoyo/srcs/yoyo_zone_initialize.c
+++ b/yoyo/srcs/yoyo_zone_initialize.c
@@ -24,7 +24,7 @@ t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_class zone_cla
 		DEBUGERR("failed for class: %d", zone_class);
 		return NULL;
 	}
-	DEBUGOUT("allocated %zu bytes region at %p", zone_bytes, zone);
+	DEBUGOUT("ALLOCATED %zu bytes region at %p", zone_bytes, zone);
 	if (!init_zone(arena, zone, zone_class)) {
 		deallocate_memory(zone, zone_bytes);
 		return NULL;
@@ -43,6 +43,7 @@ bool	init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class z
 		DEBUGOUT("%s", "@multi_thread");
 	}
 	zone->multi_thread = arena->multi_thread;
+	zone->zone_class = zone_class;
 	const size_t zone_bytes = zone_bytes_for_zone_class(zone_class);
 	const size_t heap_bytes = heap_bytes_for_zone_bytes(zone_bytes);
 	const size_t bitmap_bytes = bitmap_bytes_for_zone_bytes(zone_bytes);
@@ -62,5 +63,9 @@ bool	init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_class z
 	DEBUGOUT("offset_bitmap_heads: %uB", zone->offset_bitmap_heads);
 	DEBUGOUT("offset_bitmap_used:  %uB", zone->offset_bitmap_used);
 	DEBUGOUT("offset_heap:         %uB", zone->offset_heap);
+	t_yoyo_chunk* head = (void*)zone + zone->offset_heap;
+	mark_chunk_as_free(zone, head);
+	head->blocks = zone->blocks_free;
+	zone->frees = head;
 	return true;
 }

--- a/yoyo/srcs/yoyo_zone_initialize.c
+++ b/yoyo/srcs/yoyo_zone_initialize.c
@@ -32,7 +32,7 @@ static bool	init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_
 	const size_t zone_bytes = zone_bytes_for_zone_type(zone_type);
 	const size_t heap_bytes = heap_bytes_for_zone_bytes(zone_bytes);
 	const size_t bitmap_bytes = bitmap_bytes_for_zone_bytes(zone_bytes);
-	DEBUGOUT("heap: %zuB bitmap: %zuB", heap_bytes, bitmap_bytes);
+	DEBUGOUT("heap: %zu B bitmap: %zu B", heap_bytes, bitmap_bytes);
 	zone->next = NULL;
 	zone->frees = NULL;
 	zone->free_prev = NULL;
@@ -45,9 +45,9 @@ static bool	init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_
 	zone->offset_bitmap_heads = sizeof(t_yoyo_zone);
 	zone->offset_bitmap_used = zone->offset_bitmap_heads + bitmap_bytes;
 	zone->offset_heap = zone_bytes - heap_bytes;
-	DEBUGOUT("offset_bitmap_heads: %uB", zone->offset_bitmap_heads);
-	DEBUGOUT("offset_bitmap_used:  %uB", zone->offset_bitmap_used);
-	DEBUGOUT("offset_heap:         %uB", zone->offset_heap);
+	DEBUGOUT("offset_bitmap_heads: %u B", zone->offset_bitmap_heads);
+	DEBUGOUT("offset_bitmap_used:  %u B", zone->offset_bitmap_used);
+	DEBUGOUT("offset_heap:         %u B", zone->offset_heap);
 	t_yoyo_chunk* head = (void*)zone + zone->offset_heap;
 	mark_chunk_as_free(zone, head);
 	head->blocks = zone->blocks_free;

--- a/yoyo/srcs/yoyo_zone_operation.c
+++ b/yoyo/srcs/yoyo_zone_operation.c
@@ -1,0 +1,24 @@
+#include "yoyo_internal.h"
+
+// まだ固まってない
+void	mark_chunk_as_free(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
+	const unsigned int	bi = get_block_index(zone, chunk);
+	const unsigned int	byte_index = bi / 8;
+	const unsigned int	bit_index = bi % 8;
+	unsigned char*		heads = (void*)zone + zone->offset_bitmap_heads;
+	unsigned char*		used = (void*)zone + zone->offset_bitmap_used;
+	const unsigned char	mask = (1u << bit_index);
+	heads[byte_index] |= mask;
+	used[byte_index] &= ~mask;
+}
+
+void	mark_chunk_as_used(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
+	const unsigned int	bi = get_block_index(zone, chunk);
+	const unsigned int	byte_index = bi / 8;
+	const unsigned int	bit_index = bi % 8;
+	unsigned char*		heads = (void*)zone + zone->offset_bitmap_heads;
+	unsigned char*		used = (void*)zone + zone->offset_bitmap_used;
+	const unsigned char	mask = (1u << bit_index);
+	heads[byte_index] |= mask;
+	used[byte_index] |= mask;
+}

--- a/yoyo/srcs/yoyo_zone_operation.c
+++ b/yoyo/srcs/yoyo_zone_operation.c
@@ -8,7 +8,7 @@ void	unmark_chunk(t_yoyo_zone* zone, const t_yoyo_chunk* chunk) {
 	unsigned char*		heads = (void*)zone + zone->offset_bitmap_heads;
 	unsigned char*		used = (void*)zone + zone->offset_bitmap_used;
 	const unsigned char	mask = (1u << bit_index);
-	heads[byte_index] |= mask;
+	heads[byte_index] &= ~mask;
 	used[byte_index] &= ~mask;
 }
 

--- a/yoyo/srcs/yoyo_zone_operation.c
+++ b/yoyo/srcs/yoyo_zone_operation.c
@@ -1,6 +1,18 @@
 #include "yoyo_internal.h"
 
-// まだ固まってない
+// ビットマップから chunk を消す
+void	unmark_chunk(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
+	const unsigned int	bi = get_block_index(zone, chunk);
+	const unsigned int	byte_index = bi / 8;
+	const unsigned int	bit_index = bi % 8;
+	unsigned char*		heads = (void*)zone + zone->offset_bitmap_heads;
+	unsigned char*		used = (void*)zone + zone->offset_bitmap_used;
+	const unsigned char	mask = (1u << bit_index);
+	heads[byte_index] |= mask;
+	used[byte_index] &= ~mask;
+}
+
+// ビットマップにおいて chunk をフリー状態にする
 void	mark_chunk_as_free(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
 	const unsigned int	bi = get_block_index(zone, chunk);
 	const unsigned int	byte_index = bi / 8;
@@ -12,6 +24,7 @@ void	mark_chunk_as_free(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
 	used[byte_index] &= ~mask;
 }
 
+// ビットマップにおいて chunk を使用中状態にする
 void	mark_chunk_as_used(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
 	const unsigned int	bi = get_block_index(zone, chunk);
 	const unsigned int	byte_index = bi / 8;

--- a/yoyo/srcs/yoyo_zone_operation.c
+++ b/yoyo/srcs/yoyo_zone_operation.c
@@ -1,7 +1,7 @@
 #include "yoyo_internal.h"
 
 // ビットマップから chunk を消す
-void	unmark_chunk(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
+void	unmark_chunk(t_yoyo_zone* zone, const t_yoyo_chunk* chunk) {
 	const unsigned int	bi = get_block_index(zone, chunk);
 	const unsigned int	byte_index = bi / 8;
 	const unsigned int	bit_index = bi % 8;
@@ -13,7 +13,7 @@ void	unmark_chunk(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
 }
 
 // ビットマップにおいて chunk をフリー状態にする
-void	mark_chunk_as_free(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
+void	mark_chunk_as_free(t_yoyo_zone* zone, const t_yoyo_chunk* chunk) {
 	const unsigned int	bi = get_block_index(zone, chunk);
 	const unsigned int	byte_index = bi / 8;
 	const unsigned int	bit_index = bi % 8;
@@ -25,7 +25,7 @@ void	mark_chunk_as_free(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
 }
 
 // ビットマップにおいて chunk を使用中状態にする
-void	mark_chunk_as_used(t_yoyo_zone* zone, t_yoyo_chunk* chunk) {
+void	mark_chunk_as_used(t_yoyo_zone* zone, const t_yoyo_chunk* chunk) {
 	const unsigned int	bi = get_block_index(zone, chunk);
 	const unsigned int	byte_index = bi / 8;
 	const unsigned int	bit_index = bi % 8;

--- a/yoyo/srcs/yoyo_zone_utils.c
+++ b/yoyo/srcs/yoyo_zone_utils.c
@@ -36,7 +36,7 @@ t_yoyo_zone_type	zone_type_for_bytes(size_t n) {
 }
 
 // head にあるブロックの, その zone (の heap)におけるインデックスを求める.
-unsigned int	get_block_index(t_yoyo_zone* zone, t_yoyo_chunk* head) {
-	t_yoyo_chunk*	heap_start = (void*)zone + zone->offset_heap;
+unsigned int	get_block_index(const t_yoyo_zone* zone, const t_yoyo_chunk* head) {
+	const t_yoyo_chunk*	heap_start = (void*)zone + zone->offset_heap;
 	return head - heap_start;
 }

--- a/yoyo/srcs/yoyo_zone_utils.c
+++ b/yoyo/srcs/yoyo_zone_utils.c
@@ -11,6 +11,16 @@ size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class) {
 	}
 }
 
+size_t	max_chunk_blocks_for_zone_class(t_yoyo_zone_class zone_class) {
+	switch (zone_class) {
+		case YOYO_ZONE_TINY:
+			return TINY_MAX_CHUNK_BLOCK;
+		case YOYO_ZONE_SMALL:
+			return SMALL_MAX_CHUNK_BLOCK;
+		default:
+			return SIZE_MAX;
+	}
+}
 
 t_yoyo_zone_class	zone_class_for_bytes(size_t n) {
 	size_t	block_needed = BLOCKS_FOR_SIZE(n);
@@ -23,4 +33,10 @@ t_yoyo_zone_class	zone_class_for_bytes(size_t n) {
 	}
 	DEBUGWARN("zone for %zu B: TINY", n);
 	return YOYO_ZONE_TINY;
+}
+
+// head にあるブロックの, その zone (の heap)におけるインデックスを求める.
+unsigned int	get_block_index(t_yoyo_zone* zone, t_yoyo_chunk* head) {
+	t_yoyo_chunk*	heap_start = (void*)zone + zone->offset_heap;
+	return head - heap_start;
 }

--- a/yoyo/srcs/yoyo_zone_utils.c
+++ b/yoyo/srcs/yoyo_zone_utils.c
@@ -1,0 +1,12 @@
+#include "yoyo_internal.h"
+
+size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class) {
+	switch (zone_class) {
+		case YOYO_ZONE_TINY:
+			return ZONE_TINY_BYTE;
+		case YOYO_ZONE_SMALL:
+			return ZONE_SMALL_BYTE;
+		default:
+			return 0;
+	}
+}

--- a/yoyo/srcs/yoyo_zone_utils.c
+++ b/yoyo/srcs/yoyo_zone_utils.c
@@ -10,3 +10,17 @@ size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class) {
 			return 0;
 	}
 }
+
+
+t_yoyo_zone_class	zone_class_for_bytes(size_t n) {
+	size_t	block_needed = BLOCKS_FOR_SIZE(n);
+	if (block_needed > SMALL_MAX_CHUNK_BLOCK) {
+		DEBUGWARN("zone for %zu B: LARGE", n);
+		return YOYO_ZONE_LARGE;
+	} else if (block_needed > TINY_MAX_CHUNK_BLOCK) {
+		DEBUGWARN("zone for %zu B: SMALL", n);
+		return YOYO_ZONE_SMALL;
+	}
+	DEBUGWARN("zone for %zu B: TINY", n);
+	return YOYO_ZONE_TINY;
+}

--- a/yoyo/srcs/yoyo_zone_utils.c
+++ b/yoyo/srcs/yoyo_zone_utils.c
@@ -1,7 +1,7 @@
 #include "yoyo_internal.h"
 
-size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class) {
-	switch (zone_class) {
+size_t	zone_bytes_for_zone_type(t_yoyo_zone_type zone_type) {
+	switch (zone_type) {
 		case YOYO_ZONE_TINY:
 			return ZONE_TINY_BYTE;
 		case YOYO_ZONE_SMALL:
@@ -11,8 +11,8 @@ size_t	zone_bytes_for_zone_class(t_yoyo_zone_class zone_class) {
 	}
 }
 
-size_t	max_chunk_blocks_for_zone_class(t_yoyo_zone_class zone_class) {
-	switch (zone_class) {
+size_t	max_chunk_blocks_for_zone_type(t_yoyo_zone_type zone_type) {
+	switch (zone_type) {
 		case YOYO_ZONE_TINY:
 			return TINY_MAX_CHUNK_BLOCK;
 		case YOYO_ZONE_SMALL:
@@ -22,7 +22,7 @@ size_t	max_chunk_blocks_for_zone_class(t_yoyo_zone_class zone_class) {
 	}
 }
 
-t_yoyo_zone_class	zone_class_for_bytes(size_t n) {
+t_yoyo_zone_type	zone_type_for_bytes(size_t n) {
 	size_t	block_needed = BLOCKS_FOR_SIZE(n);
 	if (block_needed > SMALL_MAX_CHUNK_BLOCK) {
 		DEBUGWARN("zone for %zu B: LARGE", n);

--- a/yoyo/srcs/yoyo_zone_utils.c
+++ b/yoyo/srcs/yoyo_zone_utils.c
@@ -40,3 +40,24 @@ unsigned int	get_block_index(const t_yoyo_zone* zone, const t_yoyo_chunk* head) 
 	const t_yoyo_chunk*	heap_start = (void*)zone + zone->offset_heap;
 	return head - heap_start;
 }
+
+// TINY / SMALL chunk の所属する zone を返す.
+// chunk が LARGE だった場合は NULL を返す.
+t_yoyo_zone*	get_zone_of_chunk(const t_yoyo_chunk* chunk) {
+	const size_t whole_blocks = chunk->blocks;
+	DEBUGOUT("whole_blocks: %zu", whole_blocks);
+	assert(whole_blocks > 0);
+	const size_t usable_blocks = whole_blocks - 1;
+	DEBUGOUT("usable_blocks: %zu", usable_blocks);
+	assert(usable_blocks > 0);
+
+	const t_yoyo_zone_type zone_type = zone_type_for_bytes(usable_blocks * BLOCK_UNIT_SIZE);
+	DEBUGOUT("zone_type is %d", zone_type);
+	if (zone_type == YOYO_ZONE_LARGE) {
+		return NULL;
+	}
+
+	const uintptr_t zone_addr_mask = ~((zone_type == YOYO_ZONE_TINY ? ZONE_TINY_BYTE : ZONE_SMALL_BYTE) - 1);
+	DEBUGOUT("zone_addr_mask is %lx", zone_addr_mask);
+	return (t_yoyo_zone*)((uintptr_t)chunk & zone_addr_mask);
+}


### PR DESCRIPTION
- [x] `malloc` - TINY / SMALL
- [x] `malloc` - LARGE
- [x] `free` - TINY / SMALL
  - [x] チャンクの合体
- [x] `free` - LARGE
- [x] `zone`の現在状態を出力するデバッグ関数
- [x] `chunk`の現在状態を出力するデバッグ関数
- [x] `realloc` - shrink
- ~~`realloc` - extend~~
- [x] `realloc` - relocate
- [x] `show_alloc_mem` - TINY / SMALL
- [x] `show_alloc_mem` - LARGE