### PR TITLE
27 soファイル

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.a
 *.so
+*.dylib
 malloc
 mmap
 *.plist

--- a/Makefile
+++ b/Makefile
@@ -37,33 +37,46 @@ FILES_TEST	:=\
 
 OBJS_TEST	:=	$(FILES_TEST:%.c=$(OBJDIR)/%.o)
 
-CC		:=	gcc
-CFLAGS	:=	-Wall -Wextra -Werror -O2 -I$(INCDIR) -g -fsanitize=thread
+CC			:=	gcc
+CCOREFLAGS	:=	-Wall -Wextra -Werror -O2 -I$(INCDIR)
+CFLAGS		:=	$(CCOREFLAGS) #-g -fsanitize=thread
+LIBFLAGS	:=	-fPIC -fpic
 
-SONAME	:= 
+SONAME		:=	libft_malloc_$(HOSTTYPE).so
+DYLIBNAME	:=	libft_malloc_$(HOSTTYPE).dylib
 
-all:	malloc
+all:			malloc
 
-$(OBJDIR)/%.o: $(SRCDIR)/%.c
+$(OBJDIR)/%.o:	$(SRCDIR)/%.c
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CFLAGS) $(LIBFLAGS) -c $< -o $@
+
+$(OBJDIR)/%.o:	%.c
 	@mkdir -p $(OBJDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(OBJDIR)/%.o: %.c
-	@mkdir -p $(OBJDIR)
-	$(CC) $(CFLAGS) -c $< -o $@
-
-.PHONY:	malloc
-malloc:	$(NAME) $(OBJS_TEST)
+.PHONY:			malloc
+malloc:			$(NAME) $(OBJS_TEST)
 	$(CC) $(CFLAGS) -o $@ $(OBJS_TEST) $(NAME)
 	./$@
 
-$(NAME):	$(OBJS)
+$(NAME):		$(OBJS)
 	ar rcs $(NAME) $(OBJS)
 
+so:				$(SONAME)
+
+$(SONAME):		$(OBJS)
+	$(CC) -shared $^ -o $@
+
+dylib:			$(DYLIBNAME)
+
+$(DYLIBNAME):	$(OBJS)
+	$(CC) -dynamiclib $^ -o $@
+
 clean:
-	$(RM)	$(OBJDIR)
+	$(RM) $(OBJDIR)
 
-fclean:	clean
-	$(RM)	$(NAME)
+fclean:			clean
+	$(RM) $(NAME)
 
-re:		fclean all
+re:				fclean all

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ OBJS_TEST	:=	$(FILES_TEST:%.c=$(OBJDIR)/%.o)
 
 CC			:=	gcc
 CCOREFLAGS	:=	-Wall -Wextra -Werror -O2 -I$(INCDIR)
-CFLAGS		:=	$(CCOREFLAGS) #-g -fsanitize=thread
+CFLAGS		:=	$(CCOREFLAGS) -g# -fsanitize=undefined
 LIBFLAGS	:=	-fPIC -fpic
 
 BASE_LIBNAME	:=	ft_malloc
@@ -48,7 +48,7 @@ BASE_SONAME	:=	libft_malloc.so
 DYLIBNAME	:=	libft_malloc_$(HOSTTYPE).dylib
 BASE_DYLIBNAME	:=	libft_malloc.dylib
 
-all:			malloc
+all:			$(BASE_DYLIBNAME)
 
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	@mkdir -p $(OBJDIR)
@@ -59,7 +59,8 @@ $(OBJDIR)/%.o:	%.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 .PHONY:			malloc
-malloc:			$(NAME) $(OBJS_TEST)
+malloc:			$(NAME) $(OBJS_TEST) #$(BASE_DYLIBNAME)
+	# $(CC) $(CFLAGS) -o $@ $(OBJS_TEST) -L . -l $(BASE_LIBNAME)
 	$(CC) $(CFLAGS) -o $@ $(OBJS_TEST) $(NAME)
 	./$@
 
@@ -69,7 +70,7 @@ $(NAME):		$(OBJS)
 so:				$(BASE_SONAME)
 
 $(SONAME):		$(OBJS)
-	$(CC) -shared $^ -o $@
+	$(CC) -shared -fPIC $^ -o $@
 
 $(BASE_SONAME):	$(SONAME)
 	rm -f $@
@@ -78,7 +79,8 @@ $(BASE_SONAME):	$(SONAME)
 dylib:			$(BASE_DYLIBNAME)
 
 $(DYLIBNAME):	$(OBJS)
-	$(CC) -dynamiclib $^ -o $@
+	$(CC) -shared -fPIC $^ -o $@
+	# $(CC) -dynamiclib $^ -o $@
 
 $(BASE_DYLIBNAME):	$(DYLIBNAME)
 	rm -f $@

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,11 @@ CCOREFLAGS	:=	-Wall -Wextra -Werror -O2 -I$(INCDIR)
 CFLAGS		:=	$(CCOREFLAGS) #-g -fsanitize=thread
 LIBFLAGS	:=	-fPIC -fpic
 
+BASE_LIBNAME	:=	ft_malloc
 SONAME		:=	libft_malloc_$(HOSTTYPE).so
+BASE_SONAME	:=	libft_malloc.so
 DYLIBNAME	:=	libft_malloc_$(HOSTTYPE).dylib
+BASE_DYLIBNAME	:=	libft_malloc.dylib
 
 all:			malloc
 
@@ -63,15 +66,24 @@ malloc:			$(NAME) $(OBJS_TEST)
 $(NAME):		$(OBJS)
 	ar rcs $(NAME) $(OBJS)
 
-so:				$(SONAME)
+so:				$(BASE_SONAME)
 
 $(SONAME):		$(OBJS)
 	$(CC) -shared $^ -o $@
 
-dylib:			$(DYLIBNAME)
+$(BASE_SONAME):	$(SONAME)
+	rm -f $@
+	ln -s $^ $@
+
+dylib:			$(BASE_DYLIBNAME)
 
 $(DYLIBNAME):	$(OBJS)
 	$(CC) -dynamiclib $^ -o $@
+
+$(BASE_DYLIBNAME):	$(DYLIBNAME)
+	rm -f $@
+	ln -s $^ $@
+
 
 clean:
 	$(RM) $(OBJDIR)

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,17 @@ clean:
 	$(RM) $(OBJDIR)
 
 fclean:			clean
-	$(RM) $(NAME)
+	$(RM) $(NAME) $(SONAME) $(DYLIBNAME) $(BASE_SONAME) $(BASE_DYLIBNAME)
 
 re:				fclean all
+
+
+up:
+	docker-compose up --build -d
+
+down:
+	docker-compose down
+
+
+it:
+	docker-compose exec app bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+
+FROM ubuntu:latest
+RUN apt-get update && apt-get install -y\
+	g++ \
+    valgrind \
+    build-essential \
+    gdb \
+	vim
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,4 +6,6 @@ RUN apt-get update && apt-get install -y\
     build-essential \
     gdb \
 	vim
+RUN apt-get install -y emacs
+RUN apt-get install -y man-db
 

--- a/includes/common.h
+++ b/includes/common.h
@@ -15,12 +15,12 @@
 # define TX_RST "\e[0m"
 
 # ifdef NDEBUG
-#  define DEBUGSTRN(format) (0)
-#  define DEBUGSTR(format) (0)
-#  define DEBUGOUT(format, ...) (0)
-#  define DEBUGINFO(format, ...) (0)
-#  define DEBUGWARN(format, ...) (0)
-#  define DEBUGERR(format, ...) (0)
+#  define DEBUGSTRN(format) ((void)0)
+#  define DEBUGSTR(format) ((void)0)
+#  define DEBUGOUT(format, ...) ((void)0)
+#  define DEBUGINFO(format, ...) ((void)0)
+#  define DEBUGWARN(format, ...) ((void)0)
+#  define DEBUGERR(format, ...) ((void)0)
 #  define PRINT_STATE_AFTER(proc) proc;
 # else
 #  define DEBUGSTRN(format) yoyo_dprintf(STDOUT_FILENO, "%s[%s:%d %s] " format "%s", TX_GRY, __FILE__, __LINE__, __func__, TX_RST)

--- a/includes/internal.h
+++ b/includes/internal.h
@@ -11,11 +11,14 @@
 # include <sys/mman.h>
 # include <errno.h>
 # include <assert.h>
+# include <stdint.h>
 
 extern t_yoyo_realm	g_yoyo_realm;
 
 // actual_malloc.c
 void*	yoyo_actual_malloc(size_t n);
+void*	yoyo_actual_calloc(size_t count, size_t size);
+
 
 // actual_free.c
 void	yoyo_actual_free(void* addr);

--- a/includes/internal.h
+++ b/includes/internal.h
@@ -15,14 +15,14 @@
 extern t_yoyo_realm	g_yoyo_realm;
 
 // actual_malloc.c
-void*	actual_malloc(size_t n);
+void*	yoyo_actual_malloc(size_t n);
 
 // actual_free.c
-void	actual_free(void* addr);
-void	free_from_locked_tiny_small_zone(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
+void	yoyo_actual_free(void* addr);
+void	yoyo_free_from_locked_tiny_small_zone(t_yoyo_zone* zone, t_yoyo_chunk* chunk);
 
 // actual_realloc.c
-void*	actual_realloc(void* addr, size_t n);
+void*	yoyo_actual_realloc(void* addr, size_t n);
 
 // visualize.c
 void	actual_show_alloc_mem(void);
@@ -39,8 +39,8 @@ bool	unlock_subarena(t_yoyo_subarena* subarena);
 bool	unlock_zone(t_yoyo_zone* zone);
 
 // memory_alloc.c
-void*	map_memory(size_t bytes, bool align);
-void	unmap_memory(void* start, size_t size);
+void*	yoyo_map_memory(size_t bytes, bool align);
+void	yoyo_unmap_memory(void* start, size_t size);
 
 // init_realm.c
 bool	init_realm(bool multi_thread);

--- a/includes/malloc.h
+++ b/includes/malloc.h
@@ -4,6 +4,7 @@
 # include <stdlib.h>
 
 extern void*	malloc(size_t n);
+extern void*	calloc(size_t count, size_t size);
 extern void	free(void* addr);
 extern void*	realloc(void* addr, size_t n);
 extern void	show_alloc_mem(void);

--- a/includes/malloc.h
+++ b/includes/malloc.h
@@ -3,9 +3,9 @@
 
 # include <stdlib.h>
 
-void*	yoyo_malloc(size_t n);
-void	yoyo_free(void* addr);
-void*	yoyo_realloc(void* addr, size_t n);
-void	show_alloc_mem(void);
+extern void*	malloc(size_t n);
+extern void	free(void* addr);
+extern void*	realloc(void* addr, size_t n);
+extern void	show_alloc_mem(void);
 
 #endif

--- a/includes/structure.h
+++ b/includes/structure.h
@@ -144,8 +144,8 @@ typedef struct	s_yoyo_subarena {
 	pthread_mutex_t	lock;
 	// マルチスレッドモードかどうか
 	bool			multi_thread;
-	// なんかしらのポインタ
-	void*			some;
+	// なんかしらのポインタ. 直接使わないこと.
+	void*			do_not_use;
 }	t_yoyo_subarena;
 
 // [arena 構造体]
@@ -170,7 +170,7 @@ typedef struct	s_yoyo_realm {
 	// 初期化済みフラグ
 	bool			initialized;
 	// 使用可能な arena の総数.
-	// arena_count == 1 は シングルスレッドモードであることと同値.
+	// arena_count == 1 であってもシングルスレッドモードとは限らない
 	// !initialized の時は 1 とみなすこと.
 	unsigned int	arena_count;
 

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: corvvs <corvvs@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/10 18:59:27 by corvvs            #+#    #+#             */
-/*   Updated: 2023/03/05 05:30:50 by corvvs           ###   ########.fr       */
+/*   Updated: 2023/03/16 22:30:27 by corvvs           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,13 +14,6 @@
 # define LIBFT_H
 # include <stdlib.h>
 # include <stdbool.h>
-
-void	init_realm(bool);
-void*	yoyo_malloc(size_t n);
-void	yoyo_free(void* addr);
-void	show_alloc_mem(void);
-# define malloc yoyo_malloc
-# define free yoyo_free
 
 size_t	ft_strlen(const char *str);
 size_t	ft_strnlen(const char *str, size_t nmax);

--- a/main.c
+++ b/main.c
@@ -13,81 +13,81 @@ static void init_yoyo() {
 
 void	malloc_tiny_basic() {
 	void* mem;
-	mem = yoyo_malloc(1);
+	mem = malloc(1);
 	yoyo_dprintf(STDOUT_FILENO, "%p\n", mem);
-	mem = yoyo_malloc(10);
+	mem = malloc(10);
 	yoyo_dprintf(STDOUT_FILENO, "%p\n", mem);
-	mem = yoyo_malloc(100);
+	mem = malloc(100);
 	yoyo_dprintf(STDOUT_FILENO, "%p\n", mem);
 	show_alloc_mem();
 }
 
 void	malloc_tiny_all() {
 	for (int i = 0; i < 1025; ++i) {
-		void* mem = yoyo_malloc(992);
+		void* mem = malloc(992);
 		yoyo_dprintf(STDOUT_FILENO, "%d -> %p\n", i, mem);
 	}
 }
 
 void	malloc_large_basic() {
 	void* mem;
-	mem = yoyo_malloc(100000);
+	mem = malloc(100000);
 	yoyo_dprintf(STDOUT_FILENO, "%p\n", mem);
-	mem = yoyo_malloc(500000);
+	mem = malloc(500000);
 	yoyo_dprintf(STDOUT_FILENO, "%p\n", mem);
-	mem = yoyo_malloc(100000000);
+	mem = malloc(100000000);
 	yoyo_dprintf(STDOUT_FILENO, "%p\n", mem);
 }
 
 void	free_tiny_basic() {
-	void* mem1 = yoyo_malloc(1);
+	void* mem1 = malloc(1);
 	yoyo_dprintf(STDOUT_FILENO, "mem1 = %p\n", mem1);
-	void* mem2 = yoyo_malloc(1);
+	void* mem2 = malloc(1);
 	yoyo_dprintf(STDOUT_FILENO, "mem2 = %p\n", mem2);
-	void* mem3 = yoyo_malloc(1);
+	void* mem3 = malloc(1);
 	yoyo_dprintf(STDOUT_FILENO, "mem3 = %p\n", mem3);
 	show_alloc_mem();
-	yoyo_free(mem1);
-	yoyo_free(mem3);
-	yoyo_free(mem2);
+	free(mem1);
+	free(mem3);
+	free(mem2);
 	show_alloc_mem();
 }
 
 void	free_large_basic() {
 	show_alloc_mem();
-	void* mem1 = yoyo_malloc(100000);
+	void* mem1 = malloc(100000);
 	yoyo_dprintf(STDOUT_FILENO, "mem1 = %p\n", mem1);
-	void* mem2 = yoyo_malloc(500000);
+	void* mem2 = malloc(500000);
 	yoyo_dprintf(STDOUT_FILENO, "mem2 = %p\n", mem2);
-	void* mem3 = yoyo_malloc(12500000);
+	void* mem3 = malloc(12500000);
 	yoyo_dprintf(STDOUT_FILENO, "mem3 = %p\n", mem2);
 	show_alloc_mem();
 	print_memory_state(mem1);
 	print_memory_state(mem2);
 	print_memory_state(mem3);
-	yoyo_free(mem2);
-	yoyo_free(mem3);
-	yoyo_free(mem1);
+	free(mem2);
+	free(mem3);
+	free(mem1);
 	show_alloc_mem();
 }
 
 void	realloc_basic() {
-	void*	mem1 = yoyo_realloc(NULL, 60);
+	void*	mem1 = realloc(NULL, 60);
 	yoyo_dprintf(STDOUT_FILENO, "mem1 = %p\n", mem1);
-	void*	mem2 = yoyo_realloc(mem1, 20);
+	void*	mem2 = realloc(mem1, 20);
 	yoyo_dprintf(STDOUT_FILENO, "mem2 = %p\n", mem2);
-	void*	mem3 = yoyo_realloc(mem2, 24);
+	void*	mem3 = realloc(mem2, 24);
 	yoyo_dprintf(STDOUT_FILENO, "mem3 = %p\n", mem3);
 	show_alloc_mem();
-	void*	mem4 = yoyo_realloc(mem3, 4000);
+	void*	mem4 = realloc(mem3, 4000);
 	yoyo_dprintf(STDOUT_FILENO, "mem4 = %p\n", mem4);
 	show_alloc_mem();
-	void*	mem5 = yoyo_realloc(mem4, 40000);
+	void*	mem5 = realloc(mem4, 40000);
 	yoyo_dprintf(STDOUT_FILENO, "mem5 = %p\n", mem5);
-	void*	mem6 = yoyo_realloc(mem5, 20000);
+	void*	mem6 = realloc(mem5, 20000);
 	yoyo_dprintf(STDOUT_FILENO, "mem6 = %p\n", mem6);
 	show_alloc_mem();
-	void*	mem7 = yoyo_realloc(mem6, 1);
+	void*	mem7 = realloc(mem6, 1);
 	yoyo_dprintf(STDOUT_FILENO, "mem7 = %p\n", mem7);
 	show_alloc_mem();
 }

--- a/srcs/actual_malloc.c
+++ b/srcs/actual_malloc.c
@@ -32,7 +32,7 @@ static t_yoyo_large_chunk*	allocate_large_chunk(t_yoyo_large_arena* subarena, si
 	const size_t		bytes_usable = blocks_needed * BLOCK_UNIT_SIZE;
 	const size_t		bytes_large_chunk = LARGE_OFFSET_USABLE + bytes_usable;
 	const size_t		memory_byte = CEIL_BY(bytes_large_chunk, getpagesize());
-	t_yoyo_large_chunk*	large_chunk = map_memory(memory_byte, false);
+	t_yoyo_large_chunk*	large_chunk = yoyo_map_memory(memory_byte, false);
 	if (large_chunk == NULL) {
 		DEBUGERR("FAILED for %zu B", bytes);
 		return NULL;
@@ -82,7 +82,10 @@ static void	insert_large_chunk_to_subarena(
 static void*	allocate_memory_from_large(t_yoyo_large_arena* subarena, size_t n) {
 	// LARGE chunk をアロケートする.
 	t_yoyo_large_chunk*	large_chunk = allocate_large_chunk(subarena, n);
-	if (large_chunk == NULL) { return NULL; }
+	if (large_chunk == NULL) {
+		DEBUGERR("failed to allocate LARGE chunk at subarena %p for %zu B", subarena, n);
+		return NULL;
+	}
 	// アロケートした LARGE chunk を subarena のリストに接続する.
 	insert_large_chunk_to_subarena(subarena, large_chunk);
 	// 使用可能領域を返す
@@ -222,7 +225,7 @@ static void*	allocate_from_arena(t_yoyo_arena* arena, t_yoyo_zone_type zone_type
 	return allocate_memory_from_zone_list(arena, zone_type, n);
 }
 
-void*	actual_malloc(size_t n) {
+void*	yoyo_actual_malloc(size_t n) {
 	// [ゾーン種別決定]
 	t_yoyo_zone_type zone_type = zone_type_for_bytes(n);
 

--- a/srcs/actual_realloc.c
+++ b/srcs/actual_realloc.c
@@ -24,8 +24,12 @@ static void*	relocate_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
 	// [データをコピー]
 	DEBUGINFO("%s", "COPY");
 	t_yoyo_chunk*	chunk_relocated = relocated - CEILED_CHUNK_SIZE;
+	DEBUGOUT("chunk: %p", chunk);
+	DEBUGOUT("chunk_relocated: %p", chunk_relocated);
+	DEBUGOUT("chunk_relocated->blocks: %zu, chunk->blocks: %zu", chunk_relocated->blocks, chunk->blocks);
 	const size_t	blocks_copy = ((chunk_relocated->blocks < chunk->blocks) ? chunk_relocated->blocks : chunk->blocks) - 1;
 	void*			addr_current = (void*)chunk + CEILED_CHUNK_SIZE;
+	DEBUGINFO("yoyo_memcpy(%p, %p, %zu)", relocated, addr_current, blocks_copy * BLOCK_UNIT_SIZE);
 	yoyo_memcpy(relocated, addr_current, blocks_copy * BLOCK_UNIT_SIZE);
 	// [現在のチャンクを解放]
 	DEBUGINFO("%s", "DEALLOCATE");

--- a/srcs/actual_realloc.c
+++ b/srcs/actual_realloc.c
@@ -17,7 +17,7 @@ static void	*yoyo_memcpy(void* dst, const void* src, size_t n) {
 static void*	relocate_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
 	// [引っ越し先チャンクを確保]
 	DEBUGINFO("%s", "ALLOCATE");
-	void*	relocated = actual_malloc((blocks_required - 1) * BLOCK_UNIT_SIZE);
+	void*	relocated = yoyo_actual_malloc((blocks_required - 1) * BLOCK_UNIT_SIZE);
 	if (relocated == NULL) {
 		return NULL;
 	}
@@ -29,7 +29,7 @@ static void*	relocate_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
 	yoyo_memcpy(relocated, addr_current, blocks_copy * BLOCK_UNIT_SIZE);
 	// [現在のチャンクを解放]
 	DEBUGINFO("%s", "DEALLOCATE");
-	actual_free(addr_current);
+	yoyo_actual_free(addr_current);
 	return relocated;
 }
 
@@ -53,7 +53,7 @@ static void	shrink_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
 		return;
 	}
 	chunk->blocks = blocks_required;
-	free_from_locked_tiny_small_zone(zone_current, chunk_new_free);
+	yoyo_free_from_locked_tiny_small_zone(zone_current, chunk_new_free);
 	if (!unlock_zone(zone_current)) {
 		return;
 	}
@@ -61,10 +61,10 @@ static void	shrink_chunk(t_yoyo_chunk* chunk, size_t blocks_required) {
 }
 
 // 実際の realloc の動作をする
-void*	actual_realloc(void* addr, size_t n) {
+void*	yoyo_actual_realloc(void* addr, size_t n) {
 	if (addr == NULL) {
 		DEBUGWARN("addr == NULL -> delegate to malloc(%zu)", n);
-		return actual_malloc(n);
+		return yoyo_actual_malloc(n);
 	}
 	assert(CEILED_CHUNK_SIZE <= (size_t)addr);
 	t_yoyo_chunk*	chunk = addr - CEILED_CHUNK_SIZE;

--- a/srcs/debug.c
+++ b/srcs/debug.c
@@ -3,6 +3,7 @@
 // zone の状態を出力する.
 // ロックは必要なら取っておくこと.
 void	print_zone_state(const t_yoyo_zone* zone) {
+	(void)zone;
 	DEBUGINFO(
 		"ZONE %p: MT: %s, class: %d, blocks: zone %u, heap %u, free %u, used %u",
 		zone, zone->multi_thread ? "Y" : "N",
@@ -34,6 +35,7 @@ void	print_memory_state(const void* addr) {
 	if (IS_LARGE_CHUNK(chunk)) {
 		// chunk is LARGE
 		const t_yoyo_large_chunk* large_chunk = (void*)chunk - CEILED_LARGE_CHUNK_SIZE;
+		(void)large_chunk;
 		DEBUGINFO(
 			"chunk at %p is LARGE: %p, subarena: %p, total bytes: %zu B",
 			addr, large_chunk, large_chunk->subarena, large_chunk->memory_byte

--- a/srcs/malloc.c
+++ b/srcs/malloc.c
@@ -1,7 +1,14 @@
 #include "malloc.h"
 #include "internal.h"
 
-void*	yoyo_malloc(size_t n) {
+
+__attribute__((constructor))
+static void	yoyo_init() {
+	DEBUGSTR("INIT");
+	init_realm(true);	
+}
+
+void*	malloc(size_t n) {
 	DEBUGOUT("** bytes: %zu **", n);
 	SPRINT_START;
 	void	*mem = yoyo_actual_malloc(n);
@@ -10,7 +17,7 @@ void*	yoyo_malloc(size_t n) {
 	return mem;
 }
 
-void	yoyo_free(void* addr) {
+void	free(void* addr) {
 	DEBUGOUT("** addr: %p **", addr);
 	SPRINT_START;
 	yoyo_actual_free(addr);
@@ -18,7 +25,7 @@ void	yoyo_free(void* addr) {
 	DEBUGSTR("** free end **");
 }
 
-void*	yoyo_realloc(void* addr, size_t n) {
+void*	realloc(void* addr, size_t n) {
 	DEBUGOUT("** addr: %p, n: %zu **", addr, n);
 	SPRINT_START;
 	void*	mem = yoyo_actual_realloc(addr, n);
@@ -27,10 +34,17 @@ void*	yoyo_realloc(void* addr, size_t n) {
 	return mem;
 }
 
+__attribute__((visibility("default")))
 void	show_alloc_mem(void) {
 	DEBUGSTR("** show_alloc_mem **");
 	SPRINT_START;
 	actual_show_alloc_mem();
 	SPRINT_END("show_alloc_mem");
 	DEBUGSTR("** show_alloc_mem end **");
+}
+
+__attribute__((destructor))
+static void	yoyo_exit() {
+	show_alloc_mem();
+	DEBUGSTR("EXIT");
 }

--- a/srcs/malloc.c
+++ b/srcs/malloc.c
@@ -4,7 +4,7 @@
 void*	yoyo_malloc(size_t n) {
 	DEBUGOUT("** bytes: %zu **", n);
 	SPRINT_START;
-	void	*mem = actual_malloc(n);
+	void	*mem = yoyo_actual_malloc(n);
 	SPRINT_END("malloc");
 	DEBUGSTR("** malloc end **");
 	return mem;
@@ -13,7 +13,7 @@ void*	yoyo_malloc(size_t n) {
 void	yoyo_free(void* addr) {
 	DEBUGOUT("** addr: %p **", addr);
 	SPRINT_START;
-	actual_free(addr);
+	yoyo_actual_free(addr);
 	SPRINT_END("free");
 	DEBUGSTR("** free end **");
 }
@@ -21,7 +21,7 @@ void	yoyo_free(void* addr) {
 void*	yoyo_realloc(void* addr, size_t n) {
 	DEBUGOUT("** addr: %p, n: %zu **", addr, n);
 	SPRINT_START;
-	void*	mem = actual_realloc(addr, n);
+	void*	mem = yoyo_actual_realloc(addr, n);
 	SPRINT_END("realloc");
 	DEBUGSTR("** realloc end **");
 	return mem;

--- a/srcs/malloc.c
+++ b/srcs/malloc.c
@@ -13,7 +13,7 @@ void*	malloc(size_t n) {
 	SPRINT_START;
 	void	*mem = yoyo_actual_malloc(n);
 	SPRINT_END("malloc");
-	DEBUGSTR("** malloc end **");
+	DEBUGOUT("** malloc end, returning %p for %zu B **", mem, n);
 	return mem;
 }
 
@@ -30,7 +30,16 @@ void*	realloc(void* addr, size_t n) {
 	SPRINT_START;
 	void*	mem = yoyo_actual_realloc(addr, n);
 	SPRINT_END("realloc");
-	DEBUGSTR("** realloc end **");
+	DEBUGOUT("** realloc end, returning %p for %p, %zu B **", mem, addr, n);
+	return mem;
+}
+
+void*	calloc(size_t count, size_t size) {
+	DEBUGOUT("** count: %zu, size: %zu **", count, size);
+	SPRINT_START;
+	void	*mem = yoyo_actual_calloc(count, size);
+	SPRINT_END("malloc");
+	DEBUGOUT("** calloc end, returning %p for %zu x %zu B **", mem, count, size);
 	return mem;
 }
 

--- a/srcs/memory_alloc.c
+++ b/srcs/memory_alloc.c
@@ -1,7 +1,8 @@
 #include "internal.h"
 
 static void	unmap_range(void* begin, void* end) {
-	if((size_t)begin >= (size_t)end) {
+	assert((size_t)begin <= (size_t)end);
+	if((size_t)begin == (size_t)end) {
 		DEBUGOUT("skipped: [%p, %p)", begin, end);
 		return;
 	}
@@ -21,7 +22,7 @@ static void	unmap_range(void* begin, void* end) {
 // bytes バイトの領域を mmap して返す.
 // align がtrueなら領域は bytes バイトアラインされる.
 // ただしその場合 bytes が2冪でなければならない.
-void*	map_memory(size_t bytes, bool align) {
+void*	yoyo_map_memory(size_t bytes, bool align) {
 	assert(!align || ((bytes & (bytes - 1)) == 0));
 	const size_t	bulk_size = align ? 2 * bytes : bytes;
 	void*	bulk;
@@ -54,6 +55,6 @@ void*	map_memory(size_t bytes, bool align) {
 	}
 }
 
-void	unmap_memory(void* start, size_t size) {
+void	yoyo_unmap_memory(void* start, size_t size) {
 	unmap_range(start, start + size);
 }

--- a/srcs/printf.c
+++ b/srcs/printf.c
@@ -136,50 +136,56 @@ static bool	resolve_conversion(t_yoyo_printf_buffer* buffer, t_yoyo_conversion* 
 		case 'd':
 		case 'i':
 			switch (conversion->length_modifier) {
-				case YOYO_LM_DEFAULT:
-					return resolve_d(buffer, conversion, va_arg(*args, int));
 				case YOYO_LM_L:
 					return resolve_d(buffer, conversion, va_arg(*args, long));
 				case YOYO_LM_LL:
 					return resolve_d(buffer, conversion, va_arg(*args, long long));
 				case YOYO_LM_Z:
 					return resolve_d(buffer, conversion, va_arg(*args, ssize_t));
+				case YOYO_LM_DEFAULT:
+				default:
+					return resolve_d(buffer, conversion, va_arg(*args, int));
 			}
 		case 'u':
 			switch (conversion->length_modifier) {
-				case YOYO_LM_DEFAULT:
-					return resolve_u(buffer, conversion, va_arg(*args, unsigned int));
 				case YOYO_LM_L:
 					return resolve_u(buffer, conversion, va_arg(*args, unsigned long));
 				case YOYO_LM_LL:
 					return resolve_u(buffer, conversion, va_arg(*args, unsigned long long));
 				case YOYO_LM_Z:
 					return resolve_u(buffer, conversion, va_arg(*args, size_t));
+				case YOYO_LM_DEFAULT:
+				default:
+					return resolve_u(buffer, conversion, va_arg(*args, unsigned int));
 			}
 		case 'p':
 			return resolve_p(buffer, conversion, (unsigned long long)va_arg(*args, void*));
 		case 'x':
 			switch (conversion->length_modifier) {
-				case YOYO_LM_DEFAULT:
-					return resolve_x(buffer, conversion, va_arg(*args, unsigned int));
 				case YOYO_LM_L:
 					return resolve_x(buffer, conversion, va_arg(*args, unsigned long));
 				case YOYO_LM_LL:
 					return resolve_x(buffer, conversion, va_arg(*args, unsigned long long));
 				case YOYO_LM_Z:
 					return resolve_x(buffer, conversion, va_arg(*args, size_t));
+				case YOYO_LM_DEFAULT:
+				default:
+					return resolve_x(buffer, conversion, va_arg(*args, unsigned int));
 			}
 		case 'b':
 			switch (conversion->length_modifier) {
-				case YOYO_LM_DEFAULT:
-					return resolve_b(buffer, conversion, va_arg(*args, unsigned int));
 				case YOYO_LM_L:
 					return resolve_b(buffer, conversion, va_arg(*args, unsigned long));
 				case YOYO_LM_LL:
 					return resolve_b(buffer, conversion, va_arg(*args, unsigned long long));
 				case YOYO_LM_Z:
 					return resolve_b(buffer, conversion, va_arg(*args, size_t));
+				case YOYO_LM_DEFAULT:
+				default:
+					return resolve_b(buffer, conversion, va_arg(*args, unsigned int));
 			}
+		default:
+			break;
 		}
 	return false;
 }

--- a/srcs/realm_initialize.c
+++ b/srcs/realm_initialize.c
@@ -2,8 +2,6 @@
 
 t_yoyo_realm	g_yoyo_realm;
 
-pthread_mutex_t	init_mutex = PTHREAD_MUTEX_INITIALIZER;
-
 // n個までの arena を破棄する
 static void	destroy_n_arenas(unsigned int n) {
 	for (unsigned int i = 0; i < n; ++i) {
@@ -14,6 +12,8 @@ static void	destroy_n_arenas(unsigned int n) {
 // realm を初期化する.
 // スタートアップルーチンから実行される前提.
 bool	init_realm(bool multi_thread) {
+	static pthread_mutex_t	init_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 	if (pthread_mutex_lock(&init_mutex)) {
 		DEBUGERR("FAILED to lock for init: %d (%s)", errno, strerror(errno));
 		return false;
@@ -30,6 +30,7 @@ bool	init_realm(bool multi_thread) {
 		if (!succeeded) {
 			DEBUGERR("FAILED to init arena #%u", i);
 			destroy_n_arenas(i);
+			pthread_mutex_unlock(&init_mutex);
 			return false;
 		}
 	}

--- a/srcs/visualize.c
+++ b/srcs/visualize.c
@@ -1,7 +1,5 @@
 #include "internal.h"
 
-t_yoyo_realm	g_yoyo_realm;
-
 static void	visualize_chunk(const t_yoyo_chunk* chunk) {
 	yoyo_dprintf(STDOUT_FILENO, "\t\tchunk @ %p: %zu blocks (%zu B)\n", chunk, chunk->blocks, chunk->blocks * BLOCK_UNIT_SIZE);
 }
@@ -62,6 +60,7 @@ static void	visualize_large_chunk(const t_yoyo_large_chunk* large_chunk) {
 
 // LARGE サブアリーナを可視化する
 static void	visualize_locked_large_subarena(const char* zone_name, t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
+	(void)zone_type;
 	assert(zone_type == YOYO_ZONE_LARGE);
 	t_yoyo_large_arena* subarena = &arena->large;
 	if (subarena->allocated == NULL) {

--- a/srcs/zone_initialize.c
+++ b/srcs/zone_initialize.c
@@ -26,7 +26,7 @@ static bool	init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_
 			return false;
 		}
 	}
-	DEBUGOUT("%s", "@%s-thread", arena->multi_thread ? "MULTI" : "SINGLE");
+	DEBUGOUT("@%s-thread", arena->multi_thread ? "MULTI" : "SINGLE");
 	zone->multi_thread = arena->multi_thread;
 	zone->zone_type = zone_type;
 	const size_t zone_bytes = zone_bytes_for_zone_type(zone_type);

--- a/srcs/zone_initialize.c
+++ b/srcs/zone_initialize.c
@@ -59,14 +59,14 @@ static bool	init_zone(const t_yoyo_arena* arena, t_yoyo_zone* zone, t_yoyo_zone_
 // TINY / SMALL zone を mmap で確保し, 初期化して返す.
 t_yoyo_zone*	allocate_zone(const t_yoyo_arena* arena, t_yoyo_zone_type zone_type) {
 	const size_t zone_bytes = zone_bytes_for_zone_type(zone_type);
-	t_yoyo_zone* zone = map_memory(zone_bytes, true);
+	t_yoyo_zone* zone = yoyo_map_memory(zone_bytes, true);
 	if (zone == NULL) {
 		DEBUGERR("failed for class: %d", zone_type);
 		return NULL;
 	}
 	DEBUGOUT("ALLOCATED %zu bytes region at %p", zone_bytes, zone);
 	if (!init_zone(arena, zone, zone_type)) {
-		unmap_memory(zone, zone_bytes);
+		yoyo_unmap_memory(zone, zone_bytes);
 		return NULL;
 	}
 	return zone;

--- a/test_mass.c
+++ b/test_mass.c
@@ -6,16 +6,16 @@
 void	test_mass_basic(void) {
 	char*	mems[N];
 	for (int i = 0; i < N; ++i) {
-		mems[i] = yoyo_malloc(rand() % 123 + 23);
+		mems[i] = malloc(rand() % 123 + 23);
 	}
 	for (int i = 0; i < N; ++i) {
-		yoyo_free(mems[N - 1 - i]);
+		free(mems[N - 1 - i]);
 	}
 	for (int i = 0; i < N; ++i) {
-		mems[i] = yoyo_malloc(rand() % 123 + 123);
+		mems[i] = malloc(rand() % 123 + 123);
 	}
 	for (int i = 0; i < N; ++i) {
-		yoyo_free(mems[i]);
+		free(mems[i]);
 	}
 
 }

--- a/test_multithread.c
+++ b/test_multithread.c
@@ -29,10 +29,10 @@ static void*	test_multithread_basic_sub(void* index) {
 			{
 				DEBUGINFO("#%d *%d locked %d-th lock", idx, i, k);
 				if (basket.strings[k]) {
-					yoyo_free(basket.strings[k]);
+					free(basket.strings[k]);
 					basket.strings[k] = NULL;
 				}
-				char* str = yoyo_malloc(20 + rand() % 200000);
+				char* str = malloc(20 + rand() % 200000);
 				strcpy(str, "<thread #");
 				strcat(str, a);
 				strcat(str, ">");
@@ -83,7 +83,7 @@ void	test_multithread_basic(void) {
 	}
 	show_alloc_mem();
 	for (int i = 0; i < N_LOCKS; ++i) {
-		yoyo_free(basket.strings[i]);
+		free(basket.strings[i]);
 	}
 	DEBUGWARN("done: %d - %d", N_THREADS, N_LOCKS);
 	dprintf(2, "%zu\n", sizeof(t_basket_1));
@@ -111,7 +111,7 @@ static void*	test_multithread_realloc_sub(void* index) {
 			pthread_mutex_lock(&basket.locks[k]);
 			{
 				DEBUGINFO("#%d *%d locked %d-th lock", idx, i, k);
-				char* str = yoyo_realloc(basket.strings[k], 20 + rand() % 200000);
+				char* str = realloc(basket.strings[k], 20 + rand() % 200000);
 				strcpy(str, "<thread #");
 				strcat(str, a);
 				strcat(str, ">");
@@ -162,7 +162,7 @@ void	test_multithread_realloc(void) {
 	}
 	show_alloc_mem();
 	for (int i = 0; i < N_LOCKS; ++i) {
-		yoyo_free(basket.strings[i]);
+		free(basket.strings[i]);
 	}
 	DEBUGWARN("done: %d - %d", N_THREADS, N_LOCKS);
 	dprintf(2, "%zu\n", sizeof(t_basket_1));


### PR DESCRIPTION
also resolve #29 

`.so`, `.dylib`ファイルの生成にはおそらく成功しているが、それらを使って動的に`malloc`/`free`/`realloc`を差し替えるところに問題がある。

## macos

### SIP

まず、SIPが有効な環境では事実上不可能。
有効かどうかは`$ csrutil status`で調べる。

### 差し替え

SIPが効いていない環境では、以下のようにして差し替えができる:

```
$ DYLD_INSERT_LIBRARIES=./libft_malloc.so DYLD_FORCE_FLAT_NAMESPACE=1 ./a.out
```

cf. 💖 https://zenn.dev/mfunyu/articles/malloc-dynamic-link

`a.out`のリンク時には特別な処置は必要ないが、`show_alloc_mem`を使いたい場合は話が変わってくる。
(リンク時に解決される必要がある。)

### クラッシュ

差し替え自体はこれでおそらくできているのだが、(おそらく)あらゆるプログラムがクラッシュする。
デバッグログを見ると、

- `malloc(736)`, `malloc(32)`に続いて、出どころがよくわからないアドレスに対して`free`が呼ばれて、そこで落ちる。
- 落ちるのは`libft_malloc`のスタートアップルーチンに到達する前。

`a.out`, `/bin/echo`, `cat`すべてで同じ経過。

~~→ `calloc`実装で解決するかどうかあとで試す。多分違うけど。~~ → ダメだった

`free`で何もしなければ起動に成功する。

## linux

### basic

macos上のubuntuコンテナで試した。
```
# LD_PRELOAD=./libft_malloc.so cat
```

あっさり成功。

### bash / calloc

しかし

```
# LD_PRELOAD=./libft_malloc.so bash
```

はsegvする。`malloc`, `realloc`で返してないアドレスが`realloc`に渡されると死んでいるので、
これは`calloc`されたやつなのでは？と考えて`calloc`も差し替えてやるとちゃんと起動した。
しかしbashくん全然freeしてないじゃない・・・


